### PR TITLE
better handling with wrong/non-exist client ID/secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.metadata
 /pkg/
 /bin/ginkgo
+/.recommenders

--- a/api/src/main/java/org/cloudfoundry/autoscaler/api/Constants.java
+++ b/api/src/main/java/org/cloudfoundry/autoscaler/api/Constants.java
@@ -14,8 +14,8 @@ public final class Constants {
 	
     public static final int DASHBORAD_TIME_RANGE = 30;
     
-    public static final String USERNAME = "cfClientId";
-    public static final String PASSWORD = "cfClientSecret";
+    public static final String CLIENT_ID = "cfClientId";
+    public static final String CLIENT_SECRET = "cfClientSecret";
     public static final String CFURL = "cfUrl";
    
     public static final String APP_TYPE_JAVA = "java";
@@ -643,7 +643,10 @@ public final class Constants {
 	public static String[] DEFAULT_METRICS = {METRIC_TYPE_MEMORY};
 	public static Map<String,String[]> appType_metric_mapping = new HashMap<String, String[]>()
 	{
-	    {
+
+		private static final long serialVersionUID = 1L;
+
+		{
 	        put(APP_TYPE_JAVA, JAVA_METRICS);
 	        put(APP_TYPE_NODEJS, NODEJS_METRICS);
 	        put(APP_TYPE_DEFAULT, DEFAULT_METRICS);
@@ -685,7 +688,9 @@ public final class Constants {
 	public static String TRIGGER_STEPUPCOOLDOWN = "stepUpCoolDownSecs";
 	public static Map<String, Integer> trigger_default = new HashMap<String, Integer>() //server metric string to metricType
 	{
-	    {
+		private static final long serialVersionUID = 1L;
+
+		{
 	        put(TRIGGER_STATWINDOW, value_default_statWindow);
 	        put(TRIGGER_BREACHDURATION, value_default_breachDuration);
 	        put(TRIGGER_LOWERTHRESHOLD, value_default_lowerThreshold_Memory);

--- a/api/src/main/java/org/cloudfoundry/autoscaler/api/exceptions/ClientIDLoginFailedException.java
+++ b/api/src/main/java/org/cloudfoundry/autoscaler/api/exceptions/ClientIDLoginFailedException.java
@@ -1,0 +1,18 @@
+package org.cloudfoundry.autoscaler.api.exceptions;
+
+public class ClientIDLoginFailedException extends Exception{
+
+	private static final long serialVersionUID = 1L;
+
+	private String clientID ; 
+	
+	public ClientIDLoginFailedException(String id, String message) {
+		super(message);
+		clientID = id;
+	}
+	
+	public String getClientID(){
+		return clientID;
+	}
+
+}

--- a/api/src/main/java/org/cloudfoundry/autoscaler/api/filter/AuthenticationFilter.java
+++ b/api/src/main/java/org/cloudfoundry/autoscaler/api/filter/AuthenticationFilter.java
@@ -18,10 +18,12 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
 import org.cloudfoundry.autoscaler.api.exceptions.AppInfoNotFoundException;
 import org.cloudfoundry.autoscaler.api.exceptions.AppNotFoundException;
+import org.cloudfoundry.autoscaler.api.exceptions.ClientIDLoginFailedException;
 import org.cloudfoundry.autoscaler.api.util.AuthenticationTool;
 import org.cloudfoundry.autoscaler.api.util.AuthenticationTool.SecurityCheckStatus;
 import org.cloudfoundry.autoscaler.api.util.CloudFoundryManager;
 import org.cloudfoundry.autoscaler.api.util.LocaleUtil;
+import org.cloudfoundry.autoscaler.api.util.MessageUtil;
 import org.cloudfoundry.autoscaler.api.util.RestApiResponseHandler;
 /**
  * Servlet Filter implementation class SSOFilter
@@ -75,8 +77,14 @@ public class AuthenticationFilter implements Filter {
     				resp.sendError(HttpServletResponse.SC_BAD_REQUEST, RestApiResponseHandler.getErrorMessage(new AppNotFoundException(e.getAppId()), LocaleUtil.getLocale(httpServletRequest)));
     				return;
     			}
+    			catch ( ClientIDLoginFailedException e){
+    				logger.error("login UAA with client ID " + e.getClientID() + " failed");
+    				HttpServletRequest httpServletRequest = (HttpServletRequest)request;
+    				HttpServletResponse resp = (HttpServletResponse)response;
+    				resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));
+    				return;    				   				
+    			}
     			catch (Exception e){
-        			//throw new ServletException("appId=" + appGuid + " " + e.getMessage());
         			logger.error("Get exception: " + e.getClass().getName() + " with message " + e.getMessage());
         			HttpServletResponse resp = (HttpServletResponse)response;
                     resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);

--- a/api/src/main/java/org/cloudfoundry/autoscaler/api/rest/PublicRestApi.java
+++ b/api/src/main/java/org/cloudfoundry/autoscaler/api/rest/PublicRestApi.java
@@ -43,6 +43,7 @@ import org.cloudfoundry.autoscaler.api.validation.ValidateUtil.DataType;
 import org.cloudfoundry.autoscaler.api.util.LocaleUtil;
 import org.cloudfoundry.autoscaler.api.exceptions.CloudException;
 import org.cloudfoundry.autoscaler.api.exceptions.AppNotFoundException;
+import org.cloudfoundry.autoscaler.api.exceptions.ClientIDLoginFailedException;
 import org.cloudfoundry.autoscaler.api.exceptions.AppInfoNotFoundException;
 import org.cloudfoundry.autoscaler.api.exceptions.PolicyNotFoundException;
 import org.cloudfoundry.autoscaler.api.exceptions.ServiceNotFoundException;
@@ -109,6 +110,10 @@ public class PublicRestApi {
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
 		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
+		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
 			return RestApiResponseHandler.getResponseInternalServerError(new InternalServerErrorException(MessageUtil.RestResponseErrorMsg_retrieve_application_service_information_context, e), LocaleUtil.getLocale(httpServletRequest));
@@ -127,6 +132,11 @@ public class PublicRestApi {
 		catch (AppInfoNotFoundException e){
 			return RestApiResponseHandler.getResponseAppInfoNotFound(e, LocaleUtil.getLocale(httpServletRequest));
 		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
+		}
+
 		catch (Exception e){  
 			logger.info("error in getOrgSpaceByAppId: " + e.getMessage());
 			return RestApiResponseHandler.getResponseInternalServerError(new InternalServerErrorException(MessageUtil.RestResponseErrorMsg_retrieve_org_sapce_information_context, e), LocaleUtil.getLocale(httpServletRequest));
@@ -259,6 +269,10 @@ public class PublicRestApi {
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
 		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
+		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
 			return RestApiResponseHandler.getResponseInternalServerError(new InternalServerErrorException(MessageUtil.RestResponseErrorMsg_retrieve_application_service_information_context, e), LocaleUtil.getLocale(httpServletRequest));
@@ -345,6 +359,10 @@ public class PublicRestApi {
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
 		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
+		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
 			return RestApiResponseHandler.getResponseInternalServerError(new InternalServerErrorException(MessageUtil.RestResponseErrorMsg_retrieve_application_service_information_context, e), LocaleUtil.getLocale(httpServletRequest));
@@ -428,6 +446,10 @@ public class PublicRestApi {
 		}
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
+		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
 		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
@@ -523,6 +545,10 @@ public class PublicRestApi {
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
 		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
+		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
 			return RestApiResponseHandler.getResponseInternalServerError(new InternalServerErrorException(MessageUtil.RestResponseErrorMsg_retrieve_application_service_information_context, e), LocaleUtil.getLocale(httpServletRequest));
@@ -558,6 +584,10 @@ public class PublicRestApi {
 		}
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
+		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
 		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
@@ -669,6 +699,10 @@ public class PublicRestApi {
 		}
 		catch (InternalAuthenticationException e) {
 			return RestApiResponseHandler.getResponseInternalAuthenticationFail(e, LocaleUtil.getLocale(httpServletRequest));
+		}
+		catch (ClientIDLoginFailedException e){
+			logger.error("login UAA with client ID " + e.getClientID() + " failed");
+			return RestApiResponseHandler.getResponseInternalServerError(MessageUtil.getMessageString(MessageUtil.RestResponseErrorMsg_internal_server_error, LocaleUtil.getLocale(httpServletRequest)));    				   				
 		}
 		catch (Exception e) {
 			logger.info("error in getserverinfo: " + e.getMessage());
@@ -786,6 +820,10 @@ public class PublicRestApi {
 	    catch (ServiceNotFoundException e){
 	    	throw new ServiceNotFoundException(e.getServiceName(), e.getAppId());
 	    }
+		catch (ClientIDLoginFailedException e){
+			throw e ;
+		}
+
 	    catch (Exception e) {
 	    	logger.error(e.getMessage(), e);
 	    	return null;

--- a/api/src/main/java/org/cloudfoundry/autoscaler/api/util/ConfigManager.java
+++ b/api/src/main/java/org/cloudfoundry/autoscaler/api/util/ConfigManager.java
@@ -32,7 +32,6 @@ public class ConfigManager {
         }
     }
 
-
     public static String get(String key, String defaultValue) {
     	String v = get (key);
     	if (v== null)

--- a/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/PublicRestApiTest.java
+++ b/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/PublicRestApiTest.java
@@ -7,67 +7,62 @@ import static org.junit.Assert.assertEquals;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
-import org.cloudfoundry.autoscaler.api.util.CloudFoundryManager;
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.*;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.WebResource.Builder;
 import com.sun.jersey.test.framework.JerseyTest;
 
 public class PublicRestApiTest extends JerseyTest{
 	
 	
 	public  PublicRestApiTest() throws Exception{
-		super("org.cloudfoundry.autoscaler.api.rest","org.cloudfoundry.autoscaler.api.mock.cc","org.cloudfoundry.autoscaler.api.mock.serverapi");
+		super("org.cloudfoundry.autoscaler.api.rest","org.cloudfoundry.autoscaler.api.rest.mock.cc","org.cloudfoundry.autoscaler.api.rest.mock.serverapi");
 	}
 	@Test
 	public void createPolicyTest() throws Exception{
 		WebResource webResource = resource();
 		String policyStr = getPolicyContent();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/policy").type(MediaType.APPLICATION_JSON).put(ClientResponse.class,policyStr);
-        assertEquals(response.getStatus(), STATUS200);
+        assertEquals(STATUS200, response.getStatus());
 	}
 	@Test
 	public void deletePolicyTest(){
 		WebResource webResource = resource();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/policy").type(MediaType.APPLICATION_JSON).delete(ClientResponse.class);
-		assertEquals(response.getStatus(), STATUS200);
+		assertEquals(STATUS200, response.getStatus());
 	}
 	@Test
 	public void getPolicyTest(){
 		WebResource webResource = resource();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/policy").type(MediaType.APPLICATION_JSON).get(ClientResponse.class);
-		assertEquals(response.getStatus(), STATUS200);
+		assertEquals(STATUS200, response.getStatus());
 	}
 	@Test
 	public void enablePolicyTest(){
 		WebResource webResource = resource();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/policy/status").type(MediaType.APPLICATION_JSON).put(ClientResponse.class,"{ \"enable\": true}");
-		assertEquals(response.getStatus(), STATUS200);
+		assertEquals(STATUS200, response.getStatus());
 	}
 	@Test
 	public void getPolicyStatusTest(){
 		WebResource webResource = resource();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/policy/status").type(MediaType.APPLICATION_JSON).get(ClientResponse.class);
-		assertEquals(response.getStatus(), STATUS200);
+		assertEquals(STATUS200, response.getStatus());
 	}
 	@Test
 	public void getHistoryTest(){
 		WebResource webResource = resource();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/scalinghistory").type(MediaType.APPLICATION_JSON).get(ClientResponse.class);
-		assertEquals(response.getStatus(), STATUS200);
+		assertEquals(STATUS200, response.getStatus());
 	}
 	@Test
 	public void getMetricsTest(){
 		WebResource webResource = resource();
 		ClientResponse response = webResource.path("/v1/apps/" + TESTAPPID + "/metrics").type(MediaType.APPLICATION_JSON).get(ClientResponse.class);
-		assertEquals(response.getStatus(), STATUS200);
+		assertEquals(STATUS200, response.getStatus());
 	}
 	public static String getPolicyContent(){
 		BufferedReader br = new BufferedReader(new InputStreamReader(PublicRestApiTest.class.getResourceAsStream("/policy.json")));
@@ -78,7 +73,6 @@ public class PublicRestApiTest extends JerseyTest{
 				policyStr += tmp;
 			}
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		policyStr = policyStr.replaceAll("\\s+", " ");

--- a/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/mock/cc/CloudControllerRestApi.java
+++ b/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/mock/cc/CloudControllerRestApi.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.autoscaler.api.rest.mock.cc;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -13,6 +14,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.cloudfoundry.autoscaler.api.Constants;
+import org.cloudfoundry.autoscaler.api.util.ConfigManager;
 import org.cloudfoundry.autoscaler.api.util.RestApiResponseHandler;
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.*;
 import org.json.JSONObject;
@@ -42,7 +45,7 @@ public class CloudControllerRestApi {
 		jo.put("version", "1.0");
 		jo.put("description", "openAutoScaler");
 		jo.put("authorization_endpoint", "http://localhost:9998");
-		jo.put("token_endpoint", "https://uaa.stage1.ng.bluemix.net");
+		jo.put("token_endpoint", "https://localhost:9998");
 		jo.put("allow_debug", "true");
 		return RestApiResponseHandler.getResponseOk(jo.toString());
 
@@ -60,7 +63,10 @@ public class CloudControllerRestApi {
 	@Path("/oauth/token")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response getToken(@Context final HttpServletRequest httpServletRequest, String jsonString) {
+	public Response getToken(@Context final HttpServletRequest httpServletRequest, 
+			@FormParam("grant_type") final String grantType,
+			@FormParam("client_id") final String clientId,
+			@FormParam("client_secret") final String clientSecret) {
 		// {
 		// "access_token":
 		// "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIwY2JlNjKSJjsmJSFAjfsnkJWOAlsgaNSmMS1kZDExLTRlZDMtOGI0Zi1iN2U4MDRiOTc3MGIiLCJzdWIiOiJvZXJ1bnRpbWVfYWRtaW4iLCJhdXRob3JpdGllcyI6WyJjbG91ZF9jb250cm9sbGVyLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwidWFhLnJlc291cmNlIiwib3BlbmlkIiwiZG9wcGxlci5maXJlaG9zZSIsInNjaW0ucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIuYWRtaW4iXSwic2NvcGUiOlsiY2xvdWRfY29udHJvbGxlci5yZWFkIiwiY2xvdWRfY29udHJvbGxlci53cml0ZSIsInVhYS5yZXNvdXJjZSIsIm9wZW5pZCIsImRvcHBsZXIuZmlyZWhvc2UiLCJzY2ltLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLmFkbWluIl0sImNsaWVudF9pZCI6Im9lcnVudGltZV9hZG1pbiIsImNpZCI6Im9lcnVudGltZV9hZG1pbiIsImF6cCI6Im9lcnVudGltZV9hZG1pbiIsImdyYW50X3R5cGUiOiJjbGllbnRfY3JlZGVudGlhbHMiLCJyZXZfc2lnIjoiNDkyYjgwOGMiLCJpYXQiOjE0NTkyNDQwNjksImV4cCI6MTQ1OTI4NzI2OSwiaXNzIjoiaHR0cHM6Ly91YWEuc3RhZ2UxLm5nLmJsdWVtaXgubmV0L29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbIm9lcnVudGltZV9hZG1pbiIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJvcGVuaWQiLCJkb3BwbGVyIiwic2NpbSJdfQ.cA1kWFYkVu1Ll8I_khJADUONgXh6_ip45yF8PSrxIxc",
@@ -69,8 +75,15 @@ public class CloudControllerRestApi {
 		// "scope": "cloud_controller.read cloud_controller.write uaa.resource
 		// openid doppler.firehose scim.read cloud_controller.admin",
 		// "jti": "0cbe67f1-dd11-4ed3-8b4f-b7e804b9770b"
-		// }
-
+		// }		httpServletRequest.getP
+		
+		if ( (grantType == null ) || (clientId == null) || (clientSecret == null) 
+			|| !grantType.equals("client_credentials") || !clientId.equals(ConfigManager.get(Constants.CLIENT_ID)) 
+			||  !clientSecret.equals(ConfigManager.get(Constants.CLIENT_SECRET))){
+			return RestApiResponseHandler.getResponseUnauthorized("An Authentication object with grant type:'" + grantType + "', "
+							+ "client_id:'" + clientId + "' was not found in the SecurityContext");			
+		}
+		
 		JSONObject jo = new JSONObject();
 		jo.put("access_token", "eyJhbGciOiJIUzI1NiJ9");
 		jo.put("token_type", "bearer");

--- a/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/mock/serverapi/ServerMetricsRestApi.java
+++ b/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/mock/serverapi/ServerMetricsRestApi.java
@@ -2,25 +2,17 @@ package org.cloudfoundry.autoscaler.api.rest.mock.serverapi;
 
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTAPPID;
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTAPPNAME;
-import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTPOLICYID;
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTSERVICEID;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.cloudfoundry.autoscaler.api.util.RestApiResponseHandler;
-import org.json.JSONObject;
 
 @Path("/services")
 public class ServerMetricsRestApi {

--- a/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/mock/serverapi/ServerPolicyRestApi.java
+++ b/api/src/test/java/org/cloudfoundry/autoscaler/api/rest/mock/serverapi/ServerPolicyRestApi.java
@@ -1,13 +1,7 @@
 package org.cloudfoundry.autoscaler.api.rest.mock.serverapi;
 
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTAPPID;
-import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTAPPNAME;
 import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTPOLICYID;
-import static org.cloudfoundry.autoscaler.api.test.constant.Constants.TESTSERVICEID;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -22,10 +16,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+
 
 import org.cloudfoundry.autoscaler.api.util.RestApiResponseHandler;
-import org.json.JSONArray;
+
 import org.json.JSONObject;
 
 @Path("/resources")

--- a/api/src/test/java/org/cloudfoundry/autoscaler/api/util/CloudFoundryLoginTest.java
+++ b/api/src/test/java/org/cloudfoundry/autoscaler/api/util/CloudFoundryLoginTest.java
@@ -1,0 +1,49 @@
+package org.cloudfoundry.autoscaler.api.util;
+
+import org.junit.Test;
+
+import com.sun.jersey.test.framework.JerseyTest;
+
+import static org.junit.Assert.fail;
+
+import org.cloudfoundry.autoscaler.api.util.CloudFoundryManager;
+import org.cloudfoundry.autoscaler.api.Constants;
+import org.cloudfoundry.autoscaler.api.exceptions.ClientIDLoginFailedException;
+
+public class CloudFoundryLoginTest extends JerseyTest{
+		
+	public  CloudFoundryLoginTest() throws Exception{
+		super("org.cloudfoundry.autoscaler.api.rest.mock.cc");
+	}
+	
+	@Test
+	public void testCloudFoundryLogin(){
+		CloudFoundryManager manager = new CloudFoundryManager();
+		try{
+			manager.login();			
+		}
+		catch (Exception e){
+			fail("Get exception when login");
+		}
+	}
+
+	@Test(expected=ClientIDLoginFailedException.class)
+	public void testCloudFoundryLoginWithNonExistClient() throws Exception{
+		CloudFoundryManager manager = new CloudFoundryManager("non_exist_ID", "non_exist_secret", ConfigManager.get(Constants.CFURL) );
+		manager.login();
+	}
+
+	@Test(expected=ClientIDLoginFailedException.class)
+	public void testCloudFoundryLoginWithBlankClientID() throws Exception{
+		CloudFoundryManager manager = new CloudFoundryManager("", ConfigManager.get(Constants.CLIENT_SECRET), ConfigManager.get(Constants.CFURL) );
+		manager.login();
+	}
+
+	@Test(expected=ClientIDLoginFailedException.class)
+	public void testCloudFoundryLoginWithBlankClientSecret() throws Exception{
+		CloudFoundryManager manager = new CloudFoundryManager(ConfigManager.get(Constants.CLIENT_ID), "", ConfigManager.get(Constants.CFURL) );
+		manager.login();
+	}
+
+	
+}

--- a/api/src/test/java/org/cloudfoundry/autoscaler/api/util/MessageUtilTest.java
+++ b/api/src/test/java/org/cloudfoundry/autoscaler/api/util/MessageUtilTest.java
@@ -3,7 +3,6 @@ package org.cloudfoundry.autoscaler.api.util;
 import static org.junit.Assert.assertEquals;
 
 import org.cloudfoundry.autoscaler.api.util.MessageUtil;
-import org.cloudfoundry.autoscaler.api.util.LocaleUtil;
 import org.junit.Test;
 import java.util.Locale;
 


### PR DESCRIPTION
[#117837333]

- New exception for login failure
- Test cases for CloudFoundryManager login
- Exception handling for login failure
- [not part of defect #117837333] remove useless imports in API project
- [not part of defect #117837333] fix API unit test
- [not part of defect #117837333] remove compilation warnings