### PR TITLE
auto-refresh access token for metrics-collector

### DIFF
--- a/src/metricscollector/.gitignore
+++ b/src/metricscollector/.gitignore
@@ -1,3 +1,4 @@
 /out
 /logs
 /bin
+test*.go

--- a/src/metricscollector/cmd/metricscollector/main.go
+++ b/src/metricscollector/cmd/metricscollector/main.go
@@ -64,6 +64,7 @@ func main() {
 	logger.Info("create-noaa-client", map[string]interface{}{"dopplerUrl": dopplerUrl})
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	noaa := consumer.New(dopplerUrl, tlsConfig, nil)
+	noaa.RefreshTokenFrom(cfClient)
 
 	httpServer := server.NewServer(logger, conf.Server, cfClient, noaa)
 	members := grouper.Members{

--- a/src/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
+++ b/src/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
@@ -25,11 +25,12 @@ import (
 )
 
 var (
-	mcPath     string
-	cfg        config.Config
-	mcPort     int
-	configFile *os.File
-	ccNOAAUAA  *ghttp.Server
+	mcPath         string
+	cfg            config.Config
+	mcPort         int
+	configFile     *os.File
+	ccNOAAUAA      *ghttp.Server
+	isTokenExpired bool
 )
 
 func TestMetricsCollector(t *testing.T) {
@@ -64,6 +65,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	ccNOAAUAA.RouteToHandler("GET", "/apps/an-app-id/containermetrics",
 		func(rw http.ResponseWriter, r *http.Request) {
+			if isTokenExpired {
+				isTokenExpired = false
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
 			mp := multipart.NewWriter(rw)
 			defer mp.Close()
 

--- a/src/metricscollector/cmd/metricscollector/metricscollector_test.go
+++ b/src/metricscollector/cmd/metricscollector/metricscollector_test.go
@@ -95,10 +95,28 @@ var _ = Describe("MetricsCollector", func() {
 	})
 
 	Describe("when a request for memory metrics comes", func() {
-		It("returns with a 200", func() {
-			rsp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/v1/apps/an-app-id/metrics/memory", mcPort))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(rsp.StatusCode).To(Equal(http.StatusOK))
+		Context("when token is not expried", func() {
+			BeforeEach(func() {
+				isTokenExpired = false
+			})
+
+			It("returns with a 200", func() {
+				rsp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/v1/apps/an-app-id/metrics/memory", mcPort))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusOK))
+			})
 		})
+
+		Context("when token is expried", func() {
+			BeforeEach(func() {
+				isTokenExpired = true
+			})
+			It("refreshes the token and returns with a 200", func() {
+				rsp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/v1/apps/an-app-id/metrics/memory", mcPort))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusOK))
+			})
+		})
+
 	})
 })

--- a/src/metricscollector/config/config.go
+++ b/src/metricscollector/config/config.go
@@ -8,9 +8,12 @@ import (
 	"github.com/cloudfoundry-incubator/candiedyaml"
 )
 
-const GrantTypePassword = "password"
-const GrantTypeClientCredentials = "client_credentials"
-const DefaultLoggingLevel = "info"
+const (
+	GrantTypePassword          = "password"
+	GrantTypeClientCredentials = "client_credentials"
+	GrantTypeRefreshToken      = "refresh_token"
+	DefaultLoggingLevel        = "info"
+)
 
 type CfConfig struct {
 	Api       string `yaml:"api"`

--- a/src/metricscollector/exampleconfig/mc.yml
+++ b/src/metricscollector/exampleconfig/mc.yml
@@ -3,6 +3,9 @@ cf:
   grant_type: "password"
   username: "admin"
   password: "admin"
+  # grant_type: "client_credentials"
+  # client_id: "admin"
+  # secret: "admin-secret"
 server:
   port: 8080
 logging:

--- a/src/metricscollector/server/fakes/fake_cf_client.go
+++ b/src/metricscollector/server/fakes/fake_cf_client.go
@@ -13,6 +13,13 @@ type FakeCfClient struct {
 	loginReturns     struct {
 		result1 error
 	}
+	RefreshAuthTokenStub        func() (string, error)
+	refreshAuthTokenMutex       sync.RWMutex
+	refreshAuthTokenArgsForCall []struct{}
+	refreshAuthTokenReturns     struct {
+		result1 string
+		result2 error
+	}
 	GetTokensStub        func() cf.Tokens
 	getTokensMutex       sync.RWMutex
 	getTokensArgsForCall []struct{}
@@ -52,6 +59,32 @@ func (fake *FakeCfClient) LoginReturns(result1 error) {
 	fake.loginReturns = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeCfClient) RefreshAuthToken() (string, error) {
+	fake.refreshAuthTokenMutex.Lock()
+	fake.refreshAuthTokenArgsForCall = append(fake.refreshAuthTokenArgsForCall, struct{}{})
+	fake.recordInvocation("RefreshAuthToken", []interface{}{})
+	fake.refreshAuthTokenMutex.Unlock()
+	if fake.RefreshAuthTokenStub != nil {
+		return fake.RefreshAuthTokenStub()
+	} else {
+		return fake.refreshAuthTokenReturns.result1, fake.refreshAuthTokenReturns.result2
+	}
+}
+
+func (fake *FakeCfClient) RefreshAuthTokenCallCount() int {
+	fake.refreshAuthTokenMutex.RLock()
+	defer fake.refreshAuthTokenMutex.RUnlock()
+	return len(fake.refreshAuthTokenArgsForCall)
+}
+
+func (fake *FakeCfClient) RefreshAuthTokenReturns(result1 string, result2 error) {
+	fake.RefreshAuthTokenStub = nil
+	fake.refreshAuthTokenReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCfClient) GetTokens() cf.Tokens {
@@ -109,6 +142,8 @@ func (fake *FakeCfClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.loginMutex.RLock()
 	defer fake.loginMutex.RUnlock()
+	fake.refreshAuthTokenMutex.RLock()
+	defer fake.refreshAuthTokenMutex.RUnlock()
 	fake.getTokensMutex.RLock()
 	defer fake.getTokensMutex.RUnlock()
 	fake.getEndpointsMutex.RLock()


### PR DESCRIPTION
[#121995347]

- refactor cf-client
- add RefreshAuthToken in cf-client
- set RefreshTokenFrom when initiating noaa
- add token refresh grant in config
- regenerate fake_cf_client due to interface change
- unit test for cf_client token refresh
- modified unit test for main.go