### PR TITLE
Refactor service broker logs to parseable json logs

### DIFF
--- a/servicebroker/lib/index.js
+++ b/servicebroker/lib/index.js
@@ -45,6 +45,6 @@ require('./routes')(app, settings);
 
 var server = app.listen(port, function() {
   var port = server.address().port;
-  logger.info('Service broker app is running and listening at port ' + port);
+  logger.info('Service broker app is running', {port: port});
 });
 module.exports = server;

--- a/servicebroker/lib/logger/logger.js
+++ b/servicebroker/lib/logger/logger.js
@@ -1,15 +1,25 @@
 // placeholder for future logging enhancement
+var util = require('util');
+
 module.exports = {
-  info: function(message) {
-    console.log(message);
-  },
-  warn: function(message) {
-    console.log(message);
+  info: function(message,context) {	
+	var logItem = {
+	  timestamp: new Date(),
+	  source: 'autoscaler:servicebroker',
+	  text: message,
+	  log_level: 'info',
+	  data: context === null ? {} : context
+	};
+	console.log (util.format('%j', logItem)); 
   },
   error: function(message, error) {
-    console.error(message, error);
-  },
-  log: function(message) {
-    console.log(message);
+    var logItem = {
+      timestamp: new Date(),
+      source: 'autoscaler:servicebroker',
+      text: message,
+      log_level: 'error',
+      data: error
+    };
+    console.error (util.format('%j', logItem));
   }
 };

--- a/servicebroker/lib/routes/binding.js
+++ b/servicebroker/lib/routes/binding.js
@@ -47,7 +47,7 @@ module.exports = function(app, settings) {
               apiServerUtil.attachPolicy(appId, policyJSON, function(error, response) {
                 if (error == null) {
                   var statusCode = response.statusCode;
-                  logger.info("Api Server response", { status_code: statusCode, response: JSON.stringify(response.body) });
+                  logger.info("Api Server response", { status_code: statusCode, response: response.body});
                   if (statusCode === 200 || statusCode === 201) {
                     t.commit();
                     res.status(statusCode).json({});
@@ -122,7 +122,7 @@ module.exports = function(app, settings) {
               apiServerUtil.detachPolicy(appId, function(error, response) {
                 if (error == null) {
                   var statusCode = response.statusCode;
-                  logger.info("Api Server response", { status_code: statusCode, response: JSON.stringify(response.body) });
+                  logger.info("Api Server response", { status_code: statusCode, response: response.body });
                   if (statusCode === 200) {
                     t.commit();
                     res.status(statusCode).json({});

--- a/servicebroker/lib/routes/serviceinstance.js
+++ b/servicebroker/lib/routes/serviceinstance.js
@@ -32,7 +32,7 @@ module.exports = function(app, settings) {
       if (err instanceof models.sequelize.UniqueConstraintError) {
         res.status(409);
       } else {
-        logger.error("Fail to handle request: " + JSON.stringify(req) + " with ERROR: " + JSON.stringify(err));
+        logger.error("Fail to handle request: ", {req: req, err: err} );
         res.status(500);
       }
       res.end();
@@ -58,7 +58,7 @@ module.exports = function(app, settings) {
         }
         res.json({});
       }).catch(function(err) {
-        logger.error("Fail to handle request: " + JSON.stringify(req) + " with ERROR: " + JSON.stringify(err));
+        logger.error("Fail to handle request: ", {req: req, err: err});
         res.status(500).end();
       });
 


### PR DESCRIPTION
1. Refactor the logger code similar to the apiserver
2. Refactor portions of the service broker code to send better context objects to the logger