### PR TITLE
When an alarm fires during the cool down period, no action is taken

### DIFF
--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -30,5 +30,7 @@ type AppMetricDB interface {
 type HistoryDB interface {
 	SaveScalingHistory(history *models.AppScalingHistory) error
 	RetrieveScalingHistories(appId string, start int64, end int64) ([]*models.AppScalingHistory, error)
+	UpdateScalingCooldownExpireTime(appId string, expireAt int64) error
+	CanScaleApp(appId string) (bool, error)
 	Close() error
 }

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -72,7 +72,7 @@ func getNumberOfMetrics() int {
 func cleanPolicyTable() {
 	_, e := dbHelper.Exec("DELETE from policy_json")
 	if e != nil {
-		Fail("can not clean policy table: " + e.Error())
+		Fail("can not clean table policy_json: " + e.Error())
 	}
 }
 
@@ -86,14 +86,14 @@ func insertPolicy(appId string, scalingPolicy *models.ScalingPolicy) {
 	_, e = dbHelper.Exec(query, appId, string(policyJson))
 
 	if e != nil {
-		Fail("can not insert data to policy table: " + e.Error())
+		Fail("can not insert data to table policy_json: " + e.Error())
 	}
 }
 
 func cleanAppMetricTable() {
 	_, e := dbHelper.Exec("DELETE from app_metric")
 	if e != nil {
-		Fail("can not clean app_metric table: " + e.Error())
+		Fail("can not clean table app_metric : " + e.Error())
 	}
 }
 
@@ -110,7 +110,7 @@ func hasAppMetric(appId, metricType string, timestamp int64) bool {
 func cleanScalingHistoryTable() {
 	_, e := dbHelper.Exec("DELETE from scalinghistory")
 	if e != nil {
-		Fail("can not clean scaling history table: " + e.Error())
+		Fail("can not clean table scalinghistory: " + e.Error())
 	}
 }
 
@@ -119,6 +119,23 @@ func hasScalingHistory(appId string, timestamp int64) bool {
 	rows, e := dbHelper.Query(query, appId, timestamp)
 	if e != nil {
 		Fail("can not query table scalinghistory: " + e.Error())
+	}
+	defer rows.Close()
+	return rows.Next()
+}
+
+func cleanScalingCooldownTable() {
+	_, e := dbHelper.Exec("DELETE from scalingcooldown")
+	if e != nil {
+		Fail("can not clean table scalingcooldown: " + e.Error())
+	}
+}
+
+func hasScalingCooldownRecord(appId string, expireAt int64) bool {
+	query := "SELECT * FROM scalingcooldown WHERE appid = $1 AND expireat = $2"
+	rows, e := dbHelper.Query(query, appId, expireAt)
+	if e != nil {
+		Fail("can not query table scalingcooldown: " + e.Error())
 	}
 	defer rows.Close()
 	return rows.Next()

--- a/src/autoscaler/scalingengine/db/scalingengine.db.changelog.yml
+++ b/src/autoscaler/scalingengine/db/scalingengine.db.changelog.yml
@@ -51,3 +51,16 @@ databaseChangeLog:
                   type: varchar
                   constraints:
                     nullable: true
+        - createTable:
+            tableName: scalingcooldown
+            columns:
+              - column:
+                  name: appid
+                  type: varchar
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expireat
+                  type: bigint
+                  constraints:
+                    nullable: false

--- a/src/autoscaler/scalingengine/fakes/fake_history_db.go
+++ b/src/autoscaler/scalingengine/fakes/fake_history_db.go
@@ -27,6 +27,24 @@ type FakeHistoryDB struct {
 		result1 []*models.AppScalingHistory
 		result2 error
 	}
+	UpdateScalingCooldownExpireTimeStub        func(appId string, expireAt int64) error
+	updateScalingCooldownExpireTimeMutex       sync.RWMutex
+	updateScalingCooldownExpireTimeArgsForCall []struct {
+		appId    string
+		expireAt int64
+	}
+	updateScalingCooldownExpireTimeReturns struct {
+		result1 error
+	}
+	CanScaleAppStub        func(appId string) (bool, error)
+	canScaleAppMutex       sync.RWMutex
+	canScaleAppArgsForCall []struct {
+		appId string
+	}
+	canScaleAppReturns struct {
+		result1 bool
+		result2 error
+	}
 	CloseStub        func() error
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct{}
@@ -106,6 +124,74 @@ func (fake *FakeHistoryDB) RetrieveScalingHistoriesReturns(result1 []*models.App
 	}{result1, result2}
 }
 
+func (fake *FakeHistoryDB) UpdateScalingCooldownExpireTime(appId string, expireAt int64) error {
+	fake.updateScalingCooldownExpireTimeMutex.Lock()
+	fake.updateScalingCooldownExpireTimeArgsForCall = append(fake.updateScalingCooldownExpireTimeArgsForCall, struct {
+		appId    string
+		expireAt int64
+	}{appId, expireAt})
+	fake.recordInvocation("UpdateScalingCooldownExpireTime", []interface{}{appId, expireAt})
+	fake.updateScalingCooldownExpireTimeMutex.Unlock()
+	if fake.UpdateScalingCooldownExpireTimeStub != nil {
+		return fake.UpdateScalingCooldownExpireTimeStub(appId, expireAt)
+	} else {
+		return fake.updateScalingCooldownExpireTimeReturns.result1
+	}
+}
+
+func (fake *FakeHistoryDB) UpdateScalingCooldownExpireTimeCallCount() int {
+	fake.updateScalingCooldownExpireTimeMutex.RLock()
+	defer fake.updateScalingCooldownExpireTimeMutex.RUnlock()
+	return len(fake.updateScalingCooldownExpireTimeArgsForCall)
+}
+
+func (fake *FakeHistoryDB) UpdateScalingCooldownExpireTimeArgsForCall(i int) (string, int64) {
+	fake.updateScalingCooldownExpireTimeMutex.RLock()
+	defer fake.updateScalingCooldownExpireTimeMutex.RUnlock()
+	return fake.updateScalingCooldownExpireTimeArgsForCall[i].appId, fake.updateScalingCooldownExpireTimeArgsForCall[i].expireAt
+}
+
+func (fake *FakeHistoryDB) UpdateScalingCooldownExpireTimeReturns(result1 error) {
+	fake.UpdateScalingCooldownExpireTimeStub = nil
+	fake.updateScalingCooldownExpireTimeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeHistoryDB) CanScaleApp(appId string) (bool, error) {
+	fake.canScaleAppMutex.Lock()
+	fake.canScaleAppArgsForCall = append(fake.canScaleAppArgsForCall, struct {
+		appId string
+	}{appId})
+	fake.recordInvocation("CanScaleApp", []interface{}{appId})
+	fake.canScaleAppMutex.Unlock()
+	if fake.CanScaleAppStub != nil {
+		return fake.CanScaleAppStub(appId)
+	} else {
+		return fake.canScaleAppReturns.result1, fake.canScaleAppReturns.result2
+	}
+}
+
+func (fake *FakeHistoryDB) CanScaleAppCallCount() int {
+	fake.canScaleAppMutex.RLock()
+	defer fake.canScaleAppMutex.RUnlock()
+	return len(fake.canScaleAppArgsForCall)
+}
+
+func (fake *FakeHistoryDB) CanScaleAppArgsForCall(i int) string {
+	fake.canScaleAppMutex.RLock()
+	defer fake.canScaleAppMutex.RUnlock()
+	return fake.canScaleAppArgsForCall[i].appId
+}
+
+func (fake *FakeHistoryDB) CanScaleAppReturns(result1 bool, result2 error) {
+	fake.CanScaleAppStub = nil
+	fake.canScaleAppReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeHistoryDB) Close() error {
 	fake.closeMutex.Lock()
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct{}{})
@@ -138,6 +224,10 @@ func (fake *FakeHistoryDB) Invocations() map[string][][]interface{} {
 	defer fake.saveScalingHistoryMutex.RUnlock()
 	fake.retrieveScalingHistoriesMutex.RLock()
 	defer fake.retrieveScalingHistoriesMutex.RUnlock()
+	fake.updateScalingCooldownExpireTimeMutex.RLock()
+	defer fake.updateScalingCooldownExpireTimeMutex.RUnlock()
+	fake.canScaleAppMutex.RLock()
+	defer fake.canScaleAppMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	return fake.invocations

--- a/src/autoscaler/scalingengine/server/applock.go
+++ b/src/autoscaler/scalingengine/server/applock.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"sync"
+)
+
+type AppLock struct {
+	applocks map[string]*sync.Mutex
+	mutex    *sync.Mutex
+}
+
+func NewAppLock() *AppLock {
+	return &AppLock{
+		applocks: map[string]*sync.Mutex{},
+		mutex:    &sync.Mutex{},
+	}
+}
+
+func (al *AppLock) Lock(appId string) {
+	al.mutex.Lock()
+	appLock := al.applocks[appId]
+	if appLock == nil {
+		appLock = &sync.Mutex{}
+		al.applocks[appId] = appLock
+	}
+	al.mutex.Unlock()
+
+	appLock.Lock()
+}
+
+func (al *AppLock) UnLock(appId string) {
+	al.mutex.Lock()
+	appLock := al.applocks[appId]
+	al.mutex.Unlock()
+
+	if appLock != nil {
+		appLock.Unlock()
+	} else {
+		panic("unlock app that was not locked")
+	}
+}

--- a/src/autoscaler/scalingengine/server/applock_test.go
+++ b/src/autoscaler/scalingengine/server/applock_test.go
@@ -1,0 +1,106 @@
+package server_test
+
+import (
+	. "autoscaler/scalingengine/server"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"time"
+)
+
+var (
+	ch      chan string
+	appLock *AppLock
+	err     interface{}
+)
+
+var _ = Describe("Applock", func() {
+	BeforeEach(func() {
+		appLock = NewAppLock()
+		ch = make(chan string)
+	})
+
+	AfterEach(func() {
+		close(ch)
+	})
+
+	Describe("Lock", func() {
+		JustBeforeEach(func() {
+			go lockApp(appLock, "an-app-id")
+		})
+		Context("when acquiring the lock of an app", func() {
+			It("gets the lock", func() {
+				Eventually(hasAcquiredLock).Should(BeTrue())
+			})
+		})
+
+		Context("when acquiring the lock of a locked app", func() {
+			BeforeEach(func() {
+				appLock.Lock("an-app-id")
+			})
+			It("waits for the lock", func() {
+				Consistently(hasAcquiredLock).Should(BeFalse())
+			})
+		})
+
+		Context("acquiring the lock of an app when there is another app locked", func() {
+			BeforeEach(func() {
+				appLock.Lock("another-app-id")
+			})
+
+			It("gets the lock", func() {
+				Eventually(hasAcquiredLock).Should(BeTrue())
+			})
+		})
+	})
+
+	Describe("Unlock", func() {
+		JustBeforeEach(func() {
+			defer func() {
+				err = recover()
+			}()
+			appLock.UnLock("an-app-id")
+		})
+		Context("when the app is new and is not locked", func() {
+			It("panics", func() {
+				Expect(err).To(Equal("unlock app that was not locked"))
+			})
+		})
+
+		Context("when an existing app is not locked", func() {
+			BeforeEach(func() {
+				appLock.Lock("an-app-id")
+				appLock.UnLock("an-app-id")
+			})
+			It("panics", func() {
+				Expect(err).To(Equal("sync: unlock of unlocked mutex"))
+			})
+		})
+
+		Context("when the app is locked", func() {
+			BeforeEach(func() {
+				appLock.Lock("an-app-id")
+			})
+			It("releases the lock", func() {
+				Expect(err).To(BeNil())
+				go lockApp(appLock, "an-app-id")
+				Eventually(hasAcquiredLock).Should(BeTrue())
+			})
+		})
+	})
+})
+
+func lockApp(aLock *AppLock, appId string) {
+	aLock.Lock(appId)
+	ch <- "done"
+}
+
+func hasAcquiredLock() bool {
+	select {
+	case <-ch:
+		return true
+	case <-time.After(5 * time.Millisecond):
+		return false
+	}
+}


### PR DESCRIPTION
[#119505393]

- add db interface to store cooldown expire time
- skip scaling if the app is in cool down period
- write scaling Igored record to history db, so that it can be quried