### PR TITLE
set/remove active schedule and change app instances accordingly

### DIFF
--- a/src/autoscaler/scalingengine/schedule/schedule_suite_test.go
+++ b/src/autoscaler/scalingengine/schedule/schedule_suite_test.go
@@ -1,0 +1,13 @@
+package schedule_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSchedule(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Schedule Suite")
+}

--- a/src/autoscaler/scalingengine/schedule/schedule_test.go
+++ b/src/autoscaler/scalingengine/schedule/schedule_test.go
@@ -1,0 +1,240 @@
+package schedule_test
+
+import (
+	"autoscaler/models"
+	"autoscaler/scalingengine/fakes"
+
+	. "autoscaler/scalingengine/schedule"
+
+	"code.cloudfoundry.org/lager/lagertest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+
+	"errors"
+)
+
+var _ = Describe("Schedule", func() {
+
+	var (
+		schedules      *AppSchedules
+		cfc            *fakes.FakeCfClient
+		policyDB       *fakes.FakePolicyDB
+		buffer         *gbytes.Buffer
+		activeSchedule ActiveSchedule
+		err            error
+	)
+
+	BeforeEach(func() {
+		cfc = &fakes.FakeCfClient{}
+		policyDB = &fakes.FakePolicyDB{}
+		logger := lagertest.NewTestLogger("schedule-test")
+		buffer = logger.Buffer()
+		schedules = NewAppSchedules(logger, cfc, policyDB)
+		activeSchedule = ActiveSchedule{
+			ScheduleId:      "a-schedule-id",
+			InstanceInitial: 5,
+			InstanceMin:     3,
+			InstanceMax:     10,
+		}
+	})
+
+	Describe("SetActiveSchedule", func() {
+		JustBeforeEach(func() {
+			err = schedules.SetActiveSchedule("an-app-id", activeSchedule)
+		})
+
+		Context("when no active schedule exists for the app", func() {
+			It("sets the active schedule and initial instances", func() {
+				Expect(err).NotTo(HaveOccurred())
+				appId, instances := cfc.SetAppInstancesArgsForCall(0)
+				Expect(appId).To(Equal("an-app-id"))
+				Expect(instances).To(Equal(5))
+
+				schedule, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeTrue())
+				Expect(schedule).To(Equal(activeSchedule))
+			})
+
+		})
+
+		Context("when active schedule exists for the app", func() {
+			BeforeEach(func() {
+				err = schedules.SetActiveSchedule("an-app-id", ActiveSchedule{
+					ScheduleId:      "currrent-schedule-id",
+					InstanceInitial: 6,
+					InstanceMin:     2,
+					InstanceMax:     8,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Sets the new active scheule and logs the info", func() {
+				Expect(err).NotTo(HaveOccurred())
+				schedule, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeTrue())
+				Expect(schedule).To(Equal(activeSchedule))
+
+				appId, instances := cfc.SetAppInstancesArgsForCall(1)
+				Expect(appId).To(Equal("an-app-id"))
+				Expect(instances).To(Equal(5))
+
+				Eventually(buffer).Should(gbytes.Say("active schedule exists"))
+			})
+		})
+
+		Context("when fails to set initial instances number", func() {
+			BeforeEach(func() {
+				cfc.SetAppInstancesReturns(errors.New("test error"))
+			})
+			It("should sets the active schedule and return an error", func() {
+				Expect(err).To(HaveOccurred())
+
+				schedule, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeTrue())
+				Expect(schedule).To(Equal(activeSchedule))
+
+				Eventually(buffer).Should(gbytes.Say("failed-set-active-schedule-set-instance-initial"))
+				Eventually(buffer).Should(gbytes.Say("test error"))
+			})
+		})
+	})
+
+	Describe("RemoveActiveSchedule", func() {
+		JustBeforeEach(func() {
+			err = schedules.RemoveActiveSchedule("an-app-id", "a-schedule-id")
+		})
+
+		Context("when the active schedule exists", func() {
+			BeforeEach(func() {
+				err = schedules.SetActiveSchedule("an-app-id", activeSchedule)
+				Expect(err).NotTo(HaveOccurred())
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{}, nil)
+			})
+
+			It("removes the active schedule", func() {
+				Expect(err).NotTo(HaveOccurred())
+				_, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		Context("when  active schedule does not exist", func() {
+			BeforeEach(func() {
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{}, nil)
+			})
+
+			It("logs the information", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(buffer).Should(gbytes.Say("remove-active-schedule"))
+				Eventually(buffer).Should(gbytes.Say("active schedule does not exist"))
+			})
+		})
+
+		Context("when active schedule id does not match", func() {
+			BeforeEach(func() {
+				err = schedules.SetActiveSchedule("an-app-id", ActiveSchedule{
+					ScheduleId: "current-schedule-id",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{}, nil)
+			})
+
+			It("logs the information and removes the app schedule", func() {
+				Expect(err).NotTo(HaveOccurred())
+				_, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeFalse())
+
+				Eventually(buffer).Should(gbytes.Say("remove-active-schedule"))
+				Eventually(buffer).Should(gbytes.Say("schedule id does not match"))
+			})
+		})
+
+		Context("when current instance number is in the range of default policy", func() {
+			BeforeEach(func() {
+				cfc.GetAppInstancesReturns(3, nil)
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{InstanceMin: 1, InstanceMax: 5}, nil)
+			})
+
+			It("does not change the instance number", func() {
+				Expect(cfc.SetAppInstancesCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when current instance number is less than default instance-min-count", func() {
+			BeforeEach(func() {
+				cfc.GetAppInstancesReturns(1, nil)
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{InstanceMin: 3, InstanceMax: 6}, nil)
+			})
+
+			It("changes the instance number to instance-min-count", func() {
+				appId, instances := cfc.SetAppInstancesArgsForCall(0)
+				Expect(appId).To(Equal("an-app-id"))
+				Expect(instances).To(Equal(3))
+			})
+		})
+
+		Context("when current instance number is greater than default instance-max-count", func() {
+			BeforeEach(func() {
+				cfc.GetAppInstancesReturns(8, nil)
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{InstanceMin: 3, InstanceMax: 6}, nil)
+			})
+
+			It("changes the instance number to instance-max-count", func() {
+				appId, instances := cfc.SetAppInstancesArgsForCall(0)
+				Expect(appId).To(Equal("an-app-id"))
+				Expect(instances).To(Equal(6))
+			})
+		})
+
+		Context("when fails to get app policy", func() {
+			BeforeEach(func() {
+				policyDB.GetAppPolicyReturns(nil, errors.New("an error"))
+			})
+
+			It("should removes the schedule and error", func() {
+				_, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeFalse())
+
+				Expect(err).To(HaveOccurred())
+				Eventually(buffer).Should(gbytes.Say("failed-remove-active-schedule-get-app-policy"))
+				Eventually(buffer).Should(gbytes.Say("an error"))
+
+			})
+		})
+
+		Context("when fails to get current instance number", func() {
+			BeforeEach(func() {
+				cfc.GetAppInstancesReturns(0, errors.New("an error"))
+			})
+
+			It("should removes the schedule and error", func() {
+				_, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeFalse())
+
+				Expect(err).To(HaveOccurred())
+				Eventually(buffer).Should(gbytes.Say("failed-remove-active-schedule-get-app-instances"))
+				Eventually(buffer).Should(gbytes.Say("an error"))
+
+			})
+		})
+
+		Context("when fails to set instance number to default instance limit", func() {
+			BeforeEach(func() {
+				cfc.GetAppInstancesReturns(8, nil)
+				policyDB.GetAppPolicyReturns(&models.ScalingPolicy{InstanceMin: 3, InstanceMax: 6}, nil)
+				cfc.SetAppInstancesReturns(errors.New("an error"))
+			})
+
+			It("should removes the schedule and error", func() {
+				_, exists := schedules.GetActiveSchedule("an-app-id")
+				Expect(exists).To(BeFalse())
+
+				Expect(err).To(HaveOccurred())
+				Eventually(buffer).Should(gbytes.Say("failed-remove-active-schedule-set-app-instances"))
+				Eventually(buffer).Should(gbytes.Say("an error"))
+			})
+		})
+	})
+})

--- a/src/autoscaler/scalingengine/schedule/schedules.go
+++ b/src/autoscaler/scalingengine/schedule/schedules.go
@@ -1,0 +1,104 @@
+package schedule
+
+import (
+	"autoscaler/cf"
+	"autoscaler/db"
+
+	"code.cloudfoundry.org/lager"
+	"sync"
+)
+
+type ActiveSchedule struct {
+	ScheduleId      string
+	InstanceMin     int `json:"instance_min_count"`
+	InstanceMax     int `json:"instance_max_count"`
+	InstanceInitial int `json:"initial_min_instance_count"`
+}
+
+type AppSchedules struct {
+	schedules map[string]ActiveSchedule
+	lock      *sync.Mutex
+	cfClient  cf.CfClient
+	logger    lager.Logger
+	policyDB  db.PolicyDB
+}
+
+func NewAppSchedules(logger lager.Logger, cfClient cf.CfClient, policyDB db.PolicyDB) *AppSchedules {
+	return &AppSchedules{
+		schedules: make(map[string]ActiveSchedule),
+		lock:      &sync.Mutex{},
+		cfClient:  cfClient,
+		policyDB:  policyDB,
+		logger:    logger,
+	}
+}
+
+func (as *AppSchedules) GetActiveSchedule(appId string) (ActiveSchedule, bool) {
+	as.lock.Lock()
+	schedule, exists := as.schedules[appId]
+	as.lock.Unlock()
+	return schedule, exists
+}
+
+func (as *AppSchedules) SetActiveSchedule(appId string, schedule ActiveSchedule) error {
+	as.lock.Lock()
+	currentSchedule, exists := as.schedules[appId]
+	as.schedules[appId] = schedule
+	as.lock.Unlock()
+
+	logger := as.logger.WithData(lager.Data{"appId": appId})
+
+	if exists {
+		logger.Info("set-active-schedule", lager.Data{"message": "active schedule exists", "currentSchedule": currentSchedule})
+	}
+
+	err := as.cfClient.SetAppInstances(appId, schedule.InstanceInitial)
+	if err != nil {
+		logger.Error("failed-set-active-schedule-set-instance-initial", err, lager.Data{"schedule": schedule})
+		return err
+	}
+	return nil
+}
+
+func (as *AppSchedules) RemoveActiveSchedule(appId string, scheduleId string) error {
+	as.lock.Lock()
+	schedule, exists := as.schedules[appId]
+	delete(as.schedules, appId)
+	as.lock.Unlock()
+
+	logger := as.logger.WithData(lager.Data{"appId": appId, "scheduleId": scheduleId})
+
+	if !exists {
+		logger.Info("remove-active-schedule", lager.Data{"message": "active schedule does not exist"})
+	} else if schedule.ScheduleId != scheduleId {
+		logger.Info("remove-active-schedule", lager.Data{"message": "schedule id does not match", "currrentScheduleId": schedule.ScheduleId})
+	}
+
+	policy, err := as.policyDB.GetAppPolicy(appId)
+	if err != nil {
+		logger.Error("failed-remove-active-schedule-get-app-policy", err)
+		return err
+	}
+
+	instances, err := as.cfClient.GetAppInstances(appId)
+	if err != nil {
+		logger.Error("failed-remove-active-schedule-get-app-instances", err)
+		return err
+	}
+
+	if (instances < policy.InstanceMin) || (instances > policy.InstanceMax) {
+		if instances < policy.InstanceMin {
+			instances = policy.InstanceMin
+		} else {
+			instances = policy.InstanceMax
+		}
+
+		err = as.cfClient.SetAppInstances(appId, instances)
+		if err != nil {
+			logger.Error("failed-remove-active-schedule-set-app-instances", err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/autoscaler/scalingengine/server/server.go
+++ b/src/autoscaler/scalingengine/server/server.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	PathScale            = "/v1/apps/{appid}/scale"
-	PathScalingHistories = "/v1/apps/{appid}/scaling_histories"
-	RouteNameScale       = "scale"
-	RouteNameHistoreis   = "histories"
+	PathScale                = "/v1/apps/{appid}/scale"
+	PathScalingHistories     = "/v1/apps/{appid}/scaling_histories"
+	PathActiveSchedule       = "/v1/apps/{appid}/active_schedules/{scheduleid}"
+	RouteNameScale           = "scale"
+	RouteNameHistoreis       = "histories"
+	RouteNameActiveSchedules = "activeSchedules"
 )
 
 type VarsFunc func(w http.ResponseWriter, r *http.Request, vars map[string]string)
@@ -35,6 +37,8 @@ func NewServer(logger lager.Logger, conf config.ServerConfig, cfc cf.CfClient, p
 	r := mux.NewRouter()
 	r.Methods("POST").Path(PathScale).Handler(VarsFunc(handler.HandleScale)).Name(RouteNameScale)
 	r.Methods("GET").Path(PathScalingHistories).Handler(VarsFunc(handler.GetScalingHistories)).Name(RouteNameHistoreis)
+	r.Methods("PUT").Path(PathActiveSchedule).Handler(VarsFunc(handler.SetActiveSchedule)).Name(RouteNameActiveSchedules)
+	r.Methods("DELETE").Path(PathActiveSchedule).Handler(VarsFunc(handler.RemoveActiveSchedule)).Name(RouteNameActiveSchedules)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", conf.Port)
 	return http_server.New(addr, r)

--- a/src/autoscaler/scalingengine/server/server_test.go
+++ b/src/autoscaler/scalingengine/server/server_test.go
@@ -41,17 +41,16 @@ var _ = Describe("Server", func() {
 	var (
 		urlPath string
 		rsp     *http.Response
+		req     *http.Request
 		body    []byte
 		err     error
 	)
 
-	BeforeEach(func() {
-		body, err = json.Marshal(models.Trigger{Adjustment: "+1"})
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	Context("when triggering scaling action", func() {
 		BeforeEach(func() {
+			body, err = json.Marshal(models.Trigger{Adjustment: "+1"})
+			Expect(err).NotTo(HaveOccurred())
+
 			route := mux.Route{}
 			uPath, err := route.Path(PathScale).URLPath("appid", "test-app-id")
 			Expect(err).NotTo(HaveOccurred())
@@ -142,6 +141,98 @@ var _ = Describe("Server", func() {
 			})
 		})
 
+	})
+
+	Context("when setting active schedule", func() {
+		BeforeEach(func() {
+			body = []byte(`{"instance_min_count":1, "instance_max_count":5, "initial_min_instance_count":3}`)
+			route := mux.Route{}
+			uPath, err := route.Path(PathActiveSchedule).URLPath("appid", "test-app-id", "scheduleid", "test-schedule-id")
+			Expect(err).NotTo(HaveOccurred())
+			urlPath = uPath.Path
+		})
+
+		JustBeforeEach(func() {
+			rsp, err = http.DefaultClient.Do(req)
+		})
+
+		Context("when requesting correctly", func() {
+			BeforeEach(func() {
+				req, err = http.NewRequest("PUT", serverUrl+urlPath, bytes.NewReader(body))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return 200", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusOK))
+				rsp.Body.Close()
+			})
+		})
+
+		Context("when using the wrong method", func() {
+			BeforeEach(func() {
+				req, err = http.NewRequest("POST", serverUrl+urlPath, bytes.NewReader(body))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return 404", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusNotFound))
+				rsp.Body.Close()
+			})
+		})
+
+		Context("when request the wrong path", func() {
+			BeforeEach(func() {
+				req, err = http.NewRequest("PUT", serverUrl+"/not-exist-path", bytes.NewReader(body))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return 404", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusNotFound))
+				rsp.Body.Close()
+			})
+		})
+	})
+
+	Context("when deleting active schedule", func() {
+		BeforeEach(func() {
+			route := mux.Route{}
+			uPath, err := route.Path(PathActiveSchedule).URLPath("appid", "test-app-id", "scheduleid", "test-schedule-id")
+			Expect(err).NotTo(HaveOccurred())
+			urlPath = uPath.Path
+		})
+
+		JustBeforeEach(func() {
+			rsp, err = http.DefaultClient.Do(req)
+		})
+
+		Context("when requesting correctly", func() {
+			BeforeEach(func() {
+				req, err = http.NewRequest("DELETE", serverUrl+urlPath, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return 204", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusNoContent))
+				rsp.Body.Close()
+			})
+		})
+
+		Context("when request the wrong path", func() {
+			BeforeEach(func() {
+				req, err = http.NewRequest("DELETE", serverUrl+"/not-exist-path", nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return 404", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusNotFound))
+				rsp.Body.Close()
+			})
+		})
 	})
 
 })


### PR DESCRIPTION
[#119511307]

- REST API for scheduler to set/remove active schedule
- manage the active schedules in memory
- change app instances when setting/removing active schedule
    - change app instances to be initial-min-instances when setting an active schedule
    - enforce default instance limit when removing an active schedule