### PR TITLE
store raw app instances metrics to database

### DIFF
--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -14,6 +14,13 @@ type MetricsDB interface {
 	Close() error
 }
 
+type InstanceMetricsDB interface {
+	RetrieveInstanceMetrics(appid string, name string, start int64, end int64) ([]*models.AppInstanceMetric, error)
+	SaveMetric(metric *models.AppInstanceMetric) error
+	PruneMetrics(before int64) error
+	Close() error
+}
+
 type PolicyDB interface {
 	GetAppIds() (map[string]bool, error)
 	GetAppPolicy(appId string) (*models.ScalingPolicy, error)

--- a/src/autoscaler/db/sqldb/instancemetrics_sqldb.go
+++ b/src/autoscaler/db/sqldb/instancemetrics_sqldb.go
@@ -1,0 +1,118 @@
+package sqldb
+
+import (
+	"database/sql"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	_ "github.com/lib/pq"
+
+	"autoscaler/db"
+	"autoscaler/models"
+)
+
+type InstanceMetricsSQLDB struct {
+	logger lager.Logger
+	url    string
+	sqldb  *sql.DB
+}
+
+func NewInstanceMetricsSQLDB(url string, logger lager.Logger) (*InstanceMetricsSQLDB, error) {
+	sqldb, err := sql.Open(db.PostgresDriverName, url)
+	if err != nil {
+		logger.Error("failed-open-instancemetrics-db", err, lager.Data{"url": url})
+		return nil, err
+	}
+
+	err = sqldb.Ping()
+	if err != nil {
+		sqldb.Close()
+		logger.Error("failed-ping-instancemetrics-db", err, lager.Data{"url": url})
+		return nil, err
+	}
+
+	return &InstanceMetricsSQLDB{
+		sqldb:  sqldb,
+		logger: logger,
+		url:    url,
+	}, nil
+}
+
+func (idb *InstanceMetricsSQLDB) Close() error {
+	err := idb.sqldb.Close()
+	if err != nil {
+		idb.logger.Error("failed-close-instancemetrics-db", err, lager.Data{"url": idb.url})
+		return err
+	}
+	return nil
+}
+
+func (idb *InstanceMetricsSQLDB) SaveMetric(metric *models.AppInstanceMetric) error {
+	query := "INSERT INTO appinstancemetrics(appid, instanceindex, collectedat, name, unit, value, timestamp) values($1, $2, $3, $4, $5, $6, $7)"
+	_, err := idb.sqldb.Exec(query, metric.AppId, metric.InstanceIndex, metric.CollectedAt, metric.Name, metric.Unit, metric.Value, metric.Timestamp)
+
+	if err != nil {
+		idb.logger.Error("failed-insert-instancemetric-into-appinstancemetrics-table", err, lager.Data{"query": query, "metric": metric})
+	}
+	return err
+}
+
+func (idb *InstanceMetricsSQLDB) RetrieveInstanceMetrics(appid string, name string, start int64, end int64) ([]*models.AppInstanceMetric, error) {
+	query := "SELECT instanceindex, collectedat, unit, value, timestamp FROM appinstancemetrics WHERE " +
+		" appid = $1 " +
+		" AND name = $2 " +
+		" AND timestamp >= $3" +
+		" AND timestamp <= $4" +
+		" ORDER BY timestamp, instanceindex"
+
+	if end < 0 {
+		end = time.Now().UnixNano()
+	}
+
+	rows, err := idb.sqldb.Query(query, appid, name, start, end)
+	if err != nil {
+		idb.logger.Error("failed-retrieve-instancemetrics-from-appinstancemetrics-table", err,
+			lager.Data{"query": query, "appid": appid, "metricName": name, "start": start, "end": end})
+		return nil, err
+	}
+	defer rows.Close()
+
+	mtrcs := []*models.AppInstanceMetric{}
+	var index uint32
+	var collectedAt, timestamp int64
+	var unit, value string
+
+	for rows.Next() {
+		if err = rows.Scan(&index, &collectedAt, &unit, &value, &timestamp); err != nil {
+			idb.logger.Error("failed-scan-instancemetric-from-search-result", err)
+			return nil, err
+		}
+
+		length := len(mtrcs)
+		if (length > 0) && (timestamp == mtrcs[length-1].Timestamp) && (index == mtrcs[length-1].InstanceIndex) {
+			continue
+		}
+
+		metric := models.AppInstanceMetric{
+			AppId:         appid,
+			InstanceIndex: index,
+			CollectedAt:   collectedAt,
+			Name:          name,
+			Unit:          unit,
+			Value:         value,
+			Timestamp:     timestamp,
+		}
+		mtrcs = append(mtrcs, &metric)
+	}
+	return mtrcs, nil
+}
+
+func (idb *InstanceMetricsSQLDB) PruneInstanceMetrics(before int64) error {
+	query := "DELETE FROM appinstancemetrics WHERE timestamp <= $1"
+	_, err := idb.sqldb.Exec(query, before)
+	if err != nil {
+		idb.logger.Error("failed-prune-instancemetric-from-appinstancemetrics-table", err, lager.Data{"query": query, "before": before})
+	}
+
+	return err
+}

--- a/src/autoscaler/db/sqldb/instancemetrics_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/instancemetrics_sqldb_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lib/pq"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 
 	"os"
 	"time"
@@ -214,35 +215,35 @@ var _ = Describe("InstancemetricsSqldb", func() {
 		Context("when retriving all the metrics( start = 0, end = -1) ", func() {
 			It("removes duplicates and returns all the instance metrics of the app ordered by timestamp", func() {
 				Expect(err).NotTo(HaveOccurred())
-				Expect(mtrcs).To(Equal([]*models.AppInstanceMetric{
-					&models.AppInstanceMetric{
-						AppId:         "test-app-id",
-						InstanceIndex: 1,
-						CollectedAt:   111111,
-						Name:          models.MetricNameMemory,
-						Unit:          models.UnitBytes,
-						Value:         "214365",
-						Timestamp:     110000,
-					},
+				Expect(mtrcs).To(HaveLen(3))
+				Expect(*mtrcs[0]).To(gstruct.MatchAllFields(gstruct.Fields{
+					"AppId":         Equal("test-app-id"),
+					"InstanceIndex": BeEquivalentTo(1),
+					"CollectedAt":   BeEquivalentTo(111111),
+					"Name":          Equal(models.MetricNameMemory),
+					"Unit":          Equal(models.UnitBytes),
+					"Value":         Equal("214365"),
+					"Timestamp":     BeEquivalentTo(110000),
+				}))
 
-					&models.AppInstanceMetric{
-						AppId:         "test-app-id",
-						InstanceIndex: 0,
-						CollectedAt:   111111,
-						Name:          models.MetricNameMemory,
-						Unit:          models.UnitBytes,
-						Value:         "654321",
-						Timestamp:     111100,
-					},
-					&models.AppInstanceMetric{
-						AppId:         "test-app-id",
-						InstanceIndex: 1,
-						CollectedAt:   222222,
-						Name:          models.MetricNameMemory,
-						Unit:          models.UnitBytes,
-						Value:         "321765",
-						Timestamp:     222200,
-					},
+				Expect(*mtrcs[1]).To(gstruct.MatchAllFields(gstruct.Fields{
+					"AppId":         Equal("test-app-id"),
+					"InstanceIndex": BeEquivalentTo(0),
+					"CollectedAt":   BeNumerically(">=", 111111),
+					"Name":          Equal(models.MetricNameMemory),
+					"Unit":          Equal(models.UnitBytes),
+					"Value":         Equal("654321"),
+					"Timestamp":     BeEquivalentTo(111100),
+				}))
+
+				Expect(*mtrcs[2]).To(gstruct.MatchAllFields(gstruct.Fields{
+					"AppId":         Equal("test-app-id"),
+					"InstanceIndex": BeEquivalentTo(1),
+					"CollectedAt":   BeEquivalentTo(222222),
+					"Name":          Equal(models.MetricNameMemory),
+					"Unit":          Equal(models.UnitBytes),
+					"Value":         Equal("321765"),
+					"Timestamp":     BeEquivalentTo(222200),
 				}))
 			})
 		})
@@ -306,25 +307,24 @@ var _ = Describe("InstancemetricsSqldb", func() {
 
 			It("returns correct metrics", func() {
 				Expect(err).NotTo(HaveOccurred())
-				Expect(mtrcs).To(Equal([]*models.AppInstanceMetric{
-					&models.AppInstanceMetric{
-						AppId:         "test-app-id",
-						InstanceIndex: 0,
-						CollectedAt:   111111,
-						Name:          models.MetricNameMemory,
-						Unit:          models.UnitBytes,
-						Value:         "654321",
-						Timestamp:     111100,
-					},
-					&models.AppInstanceMetric{
-						AppId:         "test-app-id",
-						InstanceIndex: 1,
-						CollectedAt:   222222,
-						Name:          models.MetricNameMemory,
-						Unit:          models.UnitBytes,
-						Value:         "321765",
-						Timestamp:     222200,
-					},
+				Expect(mtrcs).To(HaveLen(2))
+				Expect(*mtrcs[0]).To(gstruct.MatchAllFields(gstruct.Fields{
+					"AppId":         Equal("test-app-id"),
+					"InstanceIndex": BeEquivalentTo(0),
+					"CollectedAt":   BeNumerically(">=", 111111),
+					"Name":          Equal(models.MetricNameMemory),
+					"Unit":          Equal(models.UnitBytes),
+					"Value":         Equal("654321"),
+					"Timestamp":     BeEquivalentTo(111100),
+				}))
+				Expect(*mtrcs[1]).To(gstruct.MatchAllFields(gstruct.Fields{
+					"AppId":         Equal("test-app-id"),
+					"InstanceIndex": BeEquivalentTo(1),
+					"CollectedAt":   BeEquivalentTo(222222),
+					"Name":          Equal(models.MetricNameMemory),
+					"Unit":          Equal(models.UnitBytes),
+					"Value":         Equal("321765"),
+					"Timestamp":     BeEquivalentTo(222200),
 				}))
 			})
 		})

--- a/src/autoscaler/db/sqldb/instancemetrics_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/instancemetrics_sqldb_test.go
@@ -1,0 +1,441 @@
+package sqldb_test
+
+import (
+	. "autoscaler/db/sqldb"
+	"autoscaler/models"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/lib/pq"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"os"
+	"time"
+)
+
+var _ = Describe("InstancemetricsSqldb", func() {
+	var (
+		url        string
+		idb        *InstanceMetricsSQLDB
+		logger     lager.Logger
+		err        error
+		metric     *models.AppInstanceMetric
+		mtrcs      []*models.AppInstanceMetric
+		start      int64
+		end        int64
+		before     int64
+		appId      string
+		metricName string
+	)
+
+	BeforeEach(func() {
+		logger = lager.NewLogger("instance-metrics-sqldb-test")
+		url = os.Getenv("DBURL")
+	})
+
+	Describe("NewInstanceMetricsSQLDB", func() {
+		JustBeforeEach(func() {
+			idb, err = NewInstanceMetricsSQLDB(url, logger)
+		})
+
+		AfterEach(func() {
+			if idb != nil {
+				err = idb.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		Context("when db url is not correct", func() {
+			BeforeEach(func() {
+				url = "postgres://not-exist-user:not-exist-password@localhost/autoscaler?sslmode=disable"
+			})
+			It("should error", func() {
+				Expect(err).To(BeAssignableToTypeOf(&pq.Error{}))
+			})
+
+		})
+
+		Context("when url is correct", func() {
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idb).NotTo(BeNil())
+			})
+		})
+	})
+
+	Describe("SaveMetric", func() {
+		BeforeEach(func() {
+			idb, err = NewInstanceMetricsSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanInstanceMetricsTable()
+		})
+
+		AfterEach(func() {
+			err = idb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("When inserting a metric", func() {
+			BeforeEach(func() {
+				metric = &models.AppInstanceMetric{
+					AppId:         "test-app-id",
+					InstanceIndex: 0,
+					CollectedAt:   111111,
+					Name:          models.MetricNameMemory,
+					Unit:          models.UnitBytes,
+					Value:         "123456",
+					Timestamp:     110000,
+				}
+				err = idb.SaveMetric(metric)
+			})
+
+			It("has the metric in database", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hasInstanceMetric("test-app-id", 0, models.MetricNameMemory, 110000)).To(BeTrue())
+			})
+		})
+
+		Context("When inserting multiple metrics", func() {
+			BeforeEach(func() {
+				metric = &models.AppInstanceMetric{
+					AppId: "test-app-id",
+					Name:  models.MetricNameMemory,
+					Unit:  models.UnitBytes,
+				}
+				metric.InstanceIndex = 0
+				metric.CollectedAt = 111111
+				metric.Value = "123456"
+				metric.Timestamp = 111100
+				err = idb.SaveMetric(metric)
+				Expect(err).NotTo(HaveOccurred())
+
+				metric.InstanceIndex = 1
+				metric.CollectedAt = 111111
+				metric.Value = "214365"
+				metric.Timestamp = 110000
+				err = idb.SaveMetric(metric)
+				Expect(err).NotTo(HaveOccurred())
+
+				metric.InstanceIndex = 0
+				metric.CollectedAt = 222222
+				metric.Value = "654321"
+				metric.Timestamp = 220000
+				err = idb.SaveMetric(metric)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("has all the metrics in database", func() {
+				Expect(hasInstanceMetric("test-app-id", 0, models.MetricNameMemory, 111100)).To(BeTrue())
+				Expect(hasInstanceMetric("test-app-id", 1, models.MetricNameMemory, 110000)).To(BeTrue())
+				Expect(hasInstanceMetric("test-app-id", 0, models.MetricNameMemory, 220000)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("RetrieveInstanceMetrics", func() {
+		BeforeEach(func() {
+			idb, err = NewInstanceMetricsSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanInstanceMetricsTable()
+
+			metric = &models.AppInstanceMetric{
+				AppId: "test-app-id",
+				Name:  models.MetricNameMemory,
+				Unit:  models.UnitBytes,
+			}
+
+			metric.InstanceIndex = 0
+			metric.CollectedAt = 111111
+			metric.Value = "654321"
+			metric.Timestamp = 111100
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			metric.InstanceIndex = 1
+			metric.CollectedAt = 111111
+			metric.Value = "214365"
+			metric.Timestamp = 110000
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			metric.InstanceIndex = 1
+			metric.CollectedAt = 222222
+			metric.Value = "321765"
+			metric.Timestamp = 222200
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			metric.InstanceIndex = 0
+			metric.CollectedAt = 222222
+			metric.Value = "654321"
+			metric.Timestamp = 111100
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			start = 0
+			end = -1
+			appId = "test-app-id"
+			metricName = models.MetricNameMemory
+
+		})
+
+		AfterEach(func() {
+			err = idb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			mtrcs, err = idb.RetrieveInstanceMetrics(appId, metricName, start, end)
+		})
+
+		Context("The app has no instance metrics", func() {
+			BeforeEach(func() {
+				appId = "app-id-no-metric"
+			})
+
+			It("returns empty metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(BeEmpty())
+			})
+
+		})
+
+		Context("when the app has no instance metrics with the given metric name", func() {
+			BeforeEach(func() {
+				metricName = "metric-name-no-metrics"
+			})
+
+			It("returns empty metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(BeEmpty())
+			})
+		})
+
+		Context("when retriving all the metrics( start = 0, end = -1) ", func() {
+			It("removes duplicates and returns all the instance metrics of the app ordered by timestamp", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(Equal([]*models.AppInstanceMetric{
+					&models.AppInstanceMetric{
+						AppId:         "test-app-id",
+						InstanceIndex: 1,
+						CollectedAt:   111111,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitBytes,
+						Value:         "214365",
+						Timestamp:     110000,
+					},
+
+					&models.AppInstanceMetric{
+						AppId:         "test-app-id",
+						InstanceIndex: 0,
+						CollectedAt:   111111,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitBytes,
+						Value:         "654321",
+						Timestamp:     111100,
+					},
+					&models.AppInstanceMetric{
+						AppId:         "test-app-id",
+						InstanceIndex: 1,
+						CollectedAt:   222222,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitBytes,
+						Value:         "321765",
+						Timestamp:     222200,
+					},
+				}))
+			})
+		})
+
+		Context("when end time = -1)", func() {
+			BeforeEach(func() {
+				start = 111111
+				end = -1
+			})
+
+			It("returns metrics from start time to now", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(HaveLen(1))
+			})
+
+		})
+
+		Context("when end time is before all the metrics timestamps", func() {
+			BeforeEach(func() {
+				start = 22222
+				end = 100000
+			})
+
+			It("returns empty metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(BeEmpty())
+			})
+
+		})
+
+		Context("when start time is after all the metrics timestamps", func() {
+			BeforeEach(func() {
+				start = 222222
+				end = 888888
+			})
+
+			It("returns empty metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(BeEmpty())
+			})
+
+		})
+
+		Context("when start time > end time", func() {
+			BeforeEach(func() {
+				start = 200000
+				end = 111111
+			})
+
+			It("returns empty metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(BeEmpty())
+			})
+		})
+
+		Context("when retrieving part of the metrics", func() {
+			BeforeEach(func() {
+				start = 111100
+				end = 222222
+			})
+
+			It("returns correct metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mtrcs).To(Equal([]*models.AppInstanceMetric{
+					&models.AppInstanceMetric{
+						AppId:         "test-app-id",
+						InstanceIndex: 0,
+						CollectedAt:   111111,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitBytes,
+						Value:         "654321",
+						Timestamp:     111100,
+					},
+					&models.AppInstanceMetric{
+						AppId:         "test-app-id",
+						InstanceIndex: 1,
+						CollectedAt:   222222,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitBytes,
+						Value:         "321765",
+						Timestamp:     222200,
+					},
+				}))
+			})
+		})
+
+		Context("when db fails", func() {
+			BeforeEach(func() {
+				idb.Close()
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("sql: .*")))
+			})
+
+		})
+	})
+
+	Describe("PruneMetrics", func() {
+		BeforeEach(func() {
+			idb, err = NewInstanceMetricsSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			cleanInstanceMetricsTable()
+
+			metric = &models.AppInstanceMetric{
+				AppId: "test-app-id",
+				Name:  models.MetricNameMemory,
+				Unit:  models.UnitBytes,
+			}
+
+			metric.InstanceIndex = 0
+			metric.CollectedAt = 111111
+			metric.Value = "654321"
+			metric.Timestamp = 111100
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			metric.InstanceIndex = 1
+			metric.CollectedAt = 111111
+			metric.Value = "214365"
+			metric.Timestamp = 110000
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			metric.InstanceIndex = 1
+			metric.CollectedAt = 222222
+			metric.Value = "321765"
+			metric.Timestamp = 222200
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+
+			metric.InstanceIndex = 0
+			metric.CollectedAt = 222222
+			metric.Value = "654321"
+			metric.Timestamp = 111100
+			err = idb.SaveMetric(metric)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err = idb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			err = idb.PruneInstanceMetrics(before)
+		})
+
+		Context("when pruning metrics before all the timestamps of metrics", func() {
+			BeforeEach(func() {
+				before = 1000
+			})
+
+			It("does not remove any metrics", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(getNumberOfInstanceMetrics()).To(Equal(4))
+			})
+		})
+
+		Context("when pruning all the metrics", func() {
+			BeforeEach(func() {
+				before = time.Now().UnixNano()
+			})
+
+			It("empties the metrics table", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(getNumberOfInstanceMetrics()).To(Equal(0))
+			})
+		})
+
+		Context("when pruning part of the metrics", func() {
+			BeforeEach(func() {
+				before = 111000
+			})
+
+			It("removes metrics before the time specified", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(getNumberOfInstanceMetrics()).To(Equal(3))
+			})
+		})
+
+		Context("when db fails", func() {
+			BeforeEach(func() {
+				idb.Close()
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("sql: .*")))
+			})
+
+		})
+
+	})
+
+})

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -50,6 +50,13 @@ func cleanMetricsTable() {
 	}
 }
 
+func cleanInstanceMetricsTable() {
+	_, e := dbHelper.Exec("DELETE FROM appinstancemetrics")
+	if e != nil {
+		Fail("can not clean table appinstancemetrics:" + e.Error())
+	}
+}
+
 func hasMetric(appId, name string, timestamp int64) bool {
 	query := "SELECT * FROM applicationmetrics WHERE appid = $1 AND name = $2 AND timestamp = $3"
 	rows, e := dbHelper.Query(query, appId, name, timestamp)
@@ -60,11 +67,30 @@ func hasMetric(appId, name string, timestamp int64) bool {
 	return rows.Next()
 }
 
+func hasInstanceMetric(appId string, index int, name string, timestamp int64) bool {
+	query := "SELECT * FROM appinstancemetrics WHERE appid = $1 AND instanceindex = $2 AND name = $3 AND timestamp = $4"
+	rows, e := dbHelper.Query(query, appId, index, name, timestamp)
+	if e != nil {
+		Fail("can not query table appinstancemetrics: " + e.Error())
+	}
+	defer rows.Close()
+	return rows.Next()
+}
+
 func getNumberOfMetrics() int {
 	var num int
 	e := dbHelper.QueryRow("SELECT COUNT(*) FROM applicationmetrics").Scan(&num)
 	if e != nil {
 		Fail("can not count the number of records in table applicationmetrics: " + e.Error())
+	}
+	return num
+}
+
+func getNumberOfInstanceMetrics() int {
+	var num int
+	e := dbHelper.QueryRow("SELECT COUNT(*) FROM appinstancemetrics").Scan(&num)
+	if e != nil {
+		Fail("can not count the number of records in table appinstancemetrics: " + e.Error())
 	}
 	return num
 }

--- a/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
+++ b/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
@@ -30,4 +30,46 @@ databaseChangeLog:
                   name: value
                   type: varchar
                   constraints:
-                    nullable: true
+                    nullable: false
+  - changeSet:
+      id: 2
+      author: byang
+      changes:
+        - createTable:
+            tableName: appinstancemetrics
+            columns:
+              - column:
+                  name: appid
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: instanceindex
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: collectedat
+                  type: bigint
+                  constraints:
+                    nullable: false                 
+              - column:
+                  name: name
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: unit
+                  type: varchar(20)
+                  constraints:
+                    nullable: false                    
+              - column:
+                  name: value
+                  type: varchar
+                  constraints:
+                    nullable: false
+              - column:
+                  name: timestamp
+                  type: bigint
+                  constraints:
+                    nullable: false    

--- a/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
+++ b/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
@@ -73,3 +73,16 @@ databaseChangeLog:
                   type: bigint
                   constraints:
                     nullable: false    
+        - createIndex:
+             columns:
+             - column:
+                 name: appid
+                 type: varchar(255)
+             - column:
+                 name: name
+                 type: varchar(100)
+             - column:
+                 name: timestamp
+                 type: bigint                
+             indexName: idx_instance_metrics
+             tableName: appinstancemetrics                    

--- a/src/autoscaler/models/metrics.go
+++ b/src/autoscaler/models/metrics.go
@@ -31,6 +31,35 @@ type InstanceMetric struct {
 	Value     string `json:"value"`
 }
 
+type AppInstanceMetric struct {
+	AppId         string `json:"app_id"`
+	InstanceIndex uint32 `json:"instance_index"`
+	CollectedAt   int64  `json:"collected_at"`
+	Name          string `json:"name"`
+	Unit          string `json:"unit"`
+	Value         string `json:"value"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+func GetInstanceMemoryMetricFromContainerEnvelopes(collectAt int64, appId string, containerEnvelopes []*events.Envelope) []*AppInstanceMetric {
+	metrics := []*AppInstanceMetric{}
+	for _, e := range containerEnvelopes {
+		cm := e.ContainerMetric
+		if *cm.ApplicationId == appId {
+			metrics = append(metrics, &AppInstanceMetric{
+				AppId:         appId,
+				InstanceIndex: uint32(cm.GetInstanceIndex()),
+				CollectedAt:   collectAt,
+				Name:          MetricNameMemory,
+				Unit:          UnitBytes,
+				Value:         fmt.Sprintf("%d", cm.GetMemoryBytes()),
+				Timestamp:     e.GetTimestamp(),
+			})
+		}
+	}
+	return metrics
+}
+
 func GetMemoryMetricFromContainerMetrics(appId string, containerMetrics []*events.Envelope) *Metric {
 	insts := []InstanceMetric{}
 	for _, e := range containerMetrics {

--- a/src/autoscaler/models/metrics_test.go
+++ b/src/autoscaler/models/metrics_test.go
@@ -18,6 +18,19 @@ func newContainerMetric(appId string, index int32, cpu float64, memory uint64, d
 	}
 }
 
+func newContainerEnvelope(timestamp int64, appId string, index int32, cpu float64, memory uint64, disk uint64) *events.Envelope {
+	return &events.Envelope{
+		Timestamp: &timestamp,
+		ContainerMetric: &events.ContainerMetric{
+			ApplicationId: &appId,
+			InstanceIndex: &index,
+			CpuPercentage: &cpu,
+			MemoryBytes:   &memory,
+			DiskBytes:     &disk,
+		},
+	}
+}
+
 var _ = Describe("Metrics", func() {
 	Describe("GetMemoryMetricFromContainerMetrics", func() {
 		var (
@@ -77,4 +90,73 @@ var _ = Describe("Metrics", func() {
 			})
 		})
 	})
+
+	Describe("GetInstanceMemoryMetricFromContainerEnvelopes", func() {
+		var (
+			containerEnvelops []*events.Envelope
+			metrics           []*AppInstanceMetric
+		)
+
+		JustBeforeEach(func() {
+			metrics = GetInstanceMemoryMetricFromContainerEnvelopes(123456, "an-app-id", containerEnvelops)
+		})
+
+		Context("when metrics are empty", func() {
+			BeforeEach(func() {
+				containerEnvelops = []*events.Envelope{}
+			})
+
+			It("should return empty instance memory metrics", func() {
+				Expect(metrics).To(BeEmpty())
+			})
+		})
+
+		Context("when no metric is available for the given app", func() {
+			BeforeEach(func() {
+				containerEnvelops = []*events.Envelope{
+					newContainerEnvelope(111111, "different-app-id", 0, 12.11, 622222, 233300000),
+					newContainerEnvelope(222222, "different-app-id", 1, 31.21, 23662, 3424553333),
+					newContainerEnvelope(333333, "another-different-app-id", 0, 0.211, 88623692, 9876384949),
+				}
+			})
+
+			It("should return empty instance memory metrics", func() {
+				Expect(metrics).To(BeEmpty())
+			})
+		})
+
+		Context("when metrics from both given app and other apps", func() {
+			BeforeEach(func() {
+				containerEnvelops = []*events.Envelope{
+					newContainerEnvelope(111111, "an-app-id", 0, 12.11, 622222, 233300000),
+					newContainerEnvelope(222222, "different-app-id", 2, 0.211, 88623692, 9876384949),
+					newContainerEnvelope(333333, "an-app-id", 1, 31.21, 23662, 3424553333),
+				}
+			})
+
+			It("should return instance memory metrics from given app", func() {
+				Expect(metrics).To(ConsistOf(
+					&AppInstanceMetric{
+						AppId:         "an-app-id",
+						InstanceIndex: 0,
+						CollectedAt:   123456,
+						Name:          MetricNameMemory,
+						Unit:          UnitBytes,
+						Value:         "622222",
+						Timestamp:     111111,
+					},
+					&AppInstanceMetric{
+						AppId:         "an-app-id",
+						InstanceIndex: 1,
+						CollectedAt:   123456,
+						Name:          MetricNameMemory,
+						Unit:          UnitBytes,
+						Value:         "23662",
+						Timestamp:     333333,
+					},
+				))
+			})
+		})
+	})
+
 })


### PR DESCRIPTION
[#131839215]

- get raw instance metrics from loggregator
- store raw instance metrics to metrics database

Note:
1. using the raw instance metrics for aggregation will be done in story #131839361
2. will remove previous metrics table and related code after story #131839361 is done