### PR TITLE
Retry container envelopes in metrics collector

### DIFF
--- a/src/autoscaler/metricscollector/collector/apppoller.go
+++ b/src/autoscaler/metricscollector/collector/apppoller.go
@@ -9,6 +9,8 @@ import (
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 
+	"github.com/cloudfoundry/sonde-go/events"
+
 	"time"
 )
 
@@ -72,10 +74,21 @@ func (ap *appPoller) startPollMetrics() {
 func (ap *appPoller) pollMetric() {
 	ap.logger.Debug("poll-metric", lager.Data{"appid": ap.appId})
 
-	containerEnvelopes, err := ap.noaaConsumer.ContainerEnvelopes(ap.appId, "bearer"+" "+ap.cfc.GetTokens().AccessToken)
-	if err != nil {
-		ap.logger.Error("poll-metric-from-noaa", err)
-		return
+	var containerEnvelopes []*events.Envelope
+	var err error
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		if attempt != 0 {
+			ap.logger.Debug("poll-metric-from-noaa-retry", lager.Data{"attempt": attempt})
+		}
+
+		containerEnvelopes, err = ap.noaaConsumer.ContainerEnvelopes(ap.appId, "bearer"+" "+ap.cfc.GetTokens().AccessToken)
+
+		if err != nil {
+			ap.logger.Error("poll-metric-from-noaa", err)
+		} else {
+			break
+		}
 	}
 
 	metrics := models.GetInstanceMemoryMetricFromContainerEnvelopes(ap.pclock.Now().UnixNano(), ap.appId, containerEnvelopes)

--- a/src/autoscaler/metricscollector/collector/apppoller.go
+++ b/src/autoscaler/metricscollector/collector/apppoller.go
@@ -77,18 +77,18 @@ func (ap *appPoller) pollMetric() {
 	var containerEnvelopes []*events.Envelope
 	var err error
 
-	for attempt := 1; attempt <= 3; attempt++ {
-		if attempt != 0 {
-			ap.logger.Debug("poll-metric-from-noaa-retry", lager.Data{"attempt": attempt})
-		}
+	for attempt := 0; attempt < 3; attempt++ {
+		ap.logger.Debug("poll-metric-from-noaa-retry", lager.Data{"attempt": attempt + 1, "appid": ap.appId})
 
 		containerEnvelopes, err = ap.noaaConsumer.ContainerEnvelopes(ap.appId, "bearer"+" "+ap.cfc.GetTokens().AccessToken)
 
-		if err != nil {
-			ap.logger.Error("poll-metric-from-noaa", err)
-		} else {
+		if err == nil {
 			break
 		}
+	}
+
+	if err != nil {
+		ap.logger.Error("poll-metric-from-noaa", err, lager.Data{"appid": ap.appId})
 	}
 
 	metrics := models.GetInstanceMemoryMetricFromContainerEnvelopes(ap.pclock.Now().UnixNano(), ap.appId, containerEnvelopes)

--- a/src/autoscaler/metricscollector/collector/apppoller_test.go
+++ b/src/autoscaler/metricscollector/collector/apppoller_test.go
@@ -282,16 +282,12 @@ var _ = Describe("Apppoller", func() {
 			})
 
 			It("polls container envelopes successfully; logs the retries and errors", func() {
-
-				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa"))
-				Eventually(buffer).Should(gbytes.Say("apppoller test error"))
 				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa-retry"))
 
-				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa"))
-				Eventually(buffer).Should(gbytes.Say("apppoller test error"))
 				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa-retry"))
 
 				Eventually(buffer).Should(gbytes.Say("poll-metric-get-memory-metric"))
+				Eventually(noaa.ContainerEnvelopesCallCount).Should(Equal(3))
 
 			})
 		})

--- a/src/autoscaler/metricscollector/collector/apppoller_test.go
+++ b/src/autoscaler/metricscollector/collector/apppoller_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Apppoller", func() {
 					Expect(appid).To(Equal("test-app-id"))
 					Expect(token).To(Equal("bearer test-access-token"))
 
-					if noaa.ContainerEnvelopesCallCount()%2 == 0 {
+					if noaa.ContainerEnvelopesCallCount() >= 2 && noaa.ContainerEnvelopesCallCount() <= 4 {
 						return nil, errors.New("apppoller test error")
 					} else {
 						return []*events.Envelope{
@@ -252,6 +252,46 @@ var _ = Describe("Apppoller", func() {
 
 				fclock.Increment(TestPollInterval)
 				Eventually(database.SaveMetricCallCount).Should(Equal(2))
+
+			})
+		})
+
+		Context("when retrieving container envelopes fail, the metrics collector retries", func() {
+			BeforeEach(func() {
+				cfc.GetTokensReturns(cf.Tokens{AccessToken: "test-access-token"})
+
+				noaa.ContainerEnvelopesStub = func(appid string, token string) ([]*events.Envelope, error) {
+					Expect(appid).To(Equal("test-app-id"))
+					Expect(token).To(Equal("bearer test-access-token"))
+
+					if noaa.ContainerEnvelopesCallCount() < 3 {
+						return nil, errors.New("apppoller test error")
+					} else {
+						return []*events.Envelope{
+							&events.Envelope{
+								ContainerMetric: &events.ContainerMetric{
+									ApplicationId: proto.String("test-app-id"),
+									InstanceIndex: proto.Int32(0),
+									MemoryBytes:   proto.Uint64(1234),
+								},
+							},
+						}, nil
+					}
+				}
+
+			})
+
+			It("polls container envelopes successfully; logs the retries and errors", func() {
+
+				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa"))
+				Eventually(buffer).Should(gbytes.Say("apppoller test error"))
+				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa-retry"))
+
+				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa"))
+				Eventually(buffer).Should(gbytes.Say("apppoller test error"))
+				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa-retry"))
+
+				Eventually(buffer).Should(gbytes.Say("poll-metric-get-memory-metric"))
 
 			})
 		})


### PR DESCRIPTION
1. metricscollector retries 3 times in case of failure while fetching container envelopes
2. Requisite tests

Will have to refactor the code and do a more selective retry based on the noaa responses . Depends on the issue here https://github.com/cloudfoundry/noaa/issues/27