### PR TITLE
Scheduler logs converted to JSON format

### DIFF
--- a/scheduler/src/main/resources/log4j2.xml
+++ b/scheduler/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <!--<!DOCTYPE xml>-->
 <Configuration status="WARN" monitorInterval="30">
     <Properties>
-        <Property name="LOG_PATTERN">%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</Property>
+        <Property name="LOG_PATTERN">{"timestamp":"%d{ISO8601}","source":"%c{1.}:%L","log_level":"%p","message":"%replace{%msg}{\"}{\\"}"}%n</Property>
         <!-- <Property name="LOG_PATH">"logs"</Property> -->
     </Properties>
     <Appenders>


### PR DESCRIPTION
We've modified the LOG_PATTERN to have the scheduler logs in JSON format with predefined attributes. 
It doesn’t have the context object like the apiserver or the broker. We could use the Mapped Diagnostic Context (MDC) http://logback.qos.ch/manual/mdc.html to add that, but that would add some amount of complication into the scheduler logging like for example, creating JSONObjects within the java code and attach them to the logs.
Just wanted to know what you think?
