### PR TITLE
collect throughput and response time  metrics through steaming app logs

### DIFF
--- a/src/autoscaler/metricscollector/cmd/metricscollector/main.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/main.go
@@ -91,12 +91,12 @@ func main() {
 	}
 	defer policyDB.Close()
 
-	createPoller := func(appId string) collector.AppPoller {
-		return collector.NewAppPoller(logger.Session("app-poller"), appId, conf.Collector.PollInterval, cfClient, noaa, instanceMetricsDB, mcClock)
+	createAppCollector := func(appId string) collector.AppCollector {
+		return collector.NewAppPoller(logger.Session("app-poller"), appId, conf.Collector.CollectInterval, cfClient, noaa, instanceMetricsDB, mcClock)
 	}
 
 	collectServer := ifrit.RunFunc(func(signals <-chan os.Signal, ready chan<- struct{}) error {
-		mc := collector.NewCollector(conf.Collector.RefreshInterval, logger.Session("collector"), policyDB, mcClock, createPoller)
+		mc := collector.NewCollector(conf.Collector.RefreshInterval, logger.Session("collector"), policyDB, mcClock, createAppCollector)
 		mc.Start()
 
 		close(ready)

--- a/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
@@ -149,7 +149,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	cfg.Db.InstanceMetricsDbUrl = os.Getenv("DBURL")
 	cfg.Db.PolicyDbUrl = os.Getenv("DBURL")
 
-	cfg.Collector.PollInterval = 10 * time.Second
+	cfg.Collector.CollectInterval = 10 * time.Second
 	cfg.Collector.RefreshInterval = 30 * time.Second
 
 	cfg.Lock.ConsulClusterConfig = consulRunner.ConsulCluster()

--- a/src/autoscaler/metricscollector/collector/app_streamer.go
+++ b/src/autoscaler/metricscollector/collector/app_streamer.go
@@ -9,6 +9,9 @@ import (
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry/sonde-go/events"
+
+	"fmt"
+	"time"
 )
 
 type AppStreamer interface {
@@ -17,24 +20,31 @@ type AppStreamer interface {
 }
 
 type appStreamer struct {
-	appId        string
-	logger       lager.Logger
-	cfc          cf.CfClient
-	noaaConsumer noaa.NoaaConsumer
-	database     db.InstanceMetricsDB
-	doneChan     chan bool
-	sclock       clock.Clock
+	appId           string
+	logger          lager.Logger
+	collectInterval time.Duration
+	cfc             cf.CfClient
+	noaaConsumer    noaa.NoaaConsumer
+	database        db.InstanceMetricsDB
+	doneChan        chan bool
+	sclock          clock.Clock
+	numRequests     map[int32]int64
+	sumReponseTimes map[int32]int64
+	ticker          clock.Ticker
 }
 
-func NewAppStreamer(logger lager.Logger, appId string, cfc cf.CfClient, noaaConsumer noaa.NoaaConsumer, database db.InstanceMetricsDB, sclock clock.Clock) AppStreamer {
+func NewAppStreamer(logger lager.Logger, appId string, interval time.Duration, cfc cf.CfClient, noaaConsumer noaa.NoaaConsumer, database db.InstanceMetricsDB, sclock clock.Clock) AppStreamer {
 	return &appStreamer{
-		appId:        appId,
-		logger:       logger,
-		cfc:          cfc,
-		noaaConsumer: noaaConsumer,
-		database:     database,
-		doneChan:     make(chan bool),
-		sclock:       sclock,
+		appId:           appId,
+		logger:          logger,
+		collectInterval: interval,
+		cfc:             cfc,
+		noaaConsumer:    noaaConsumer,
+		database:        database,
+		doneChan:        make(chan bool),
+		sclock:          sclock,
+		numRequests:     make(map[int32]int64),
+		sumReponseTimes: make(map[int32]int64),
 	}
 }
 
@@ -49,9 +59,11 @@ func (as *appStreamer) Stop() {
 
 func (as *appStreamer) streamMetrics() {
 	eventChan, errorChan := as.noaaConsumer.Stream(as.appId, as.cfc.GetTokens().AccessToken)
+	as.ticker = as.sclock.NewTicker(as.collectInterval)
 	for {
 		select {
 		case <-as.doneChan:
+			as.ticker.Stop()
 			err := as.noaaConsumer.Close()
 			if err == nil {
 				as.logger.Info("noaa-connections-closed", lager.Data{"appid": as.appId})
@@ -66,13 +78,16 @@ func (as *appStreamer) streamMetrics() {
 
 		case event := <-eventChan:
 			as.processEvent(event)
+
+		case <-as.ticker.C():
+			as.computeAndSaveMetrics()
 		}
 	}
 }
 
 func (as *appStreamer) processEvent(event *events.Envelope) {
 	if event.GetEventType() == events.Envelope_ContainerMetric {
-		metric := models.GetInstanceMemoryMetricFromContainerMetricEvent(as.sclock.Now().UnixNano(), as.appId, event)
+		metric := noaa.GetInstanceMemoryMetricFromContainerMetricEvent(as.sclock.Now().UnixNano(), as.appId, event)
 		as.logger.Debug("process-event-get-memory-metric", lager.Data{"metric": metric})
 		if metric != nil {
 			err := as.database.SaveMetric(metric)
@@ -80,5 +95,53 @@ func (as *appStreamer) processEvent(event *events.Envelope) {
 				as.logger.Error("process-event-save-metric", err, lager.Data{"metric": metric})
 			}
 		}
+	} else if event.GetEventType() == events.Envelope_HttpStartStop {
+		ss := event.GetHttpStartStop()
+		if ss != nil {
+			as.numRequests[ss.GetInstanceIndex()]++
+			as.sumReponseTimes[ss.GetInstanceIndex()] += (ss.GetStopTimestamp() - ss.GetStartTimestamp())
+		}
 	}
+}
+
+func (as *appStreamer) computeAndSaveMetrics() {
+	for instanceIdx, numReq := range as.numRequests {
+		if numReq != 0 {
+			througput := &models.AppInstanceMetric{
+				AppId:         as.appId,
+				InstanceIndex: uint32(instanceIdx),
+				CollectedAt:   as.sclock.Now().UnixNano(),
+				Name:          models.MetricNameThroughput,
+				Unit:          models.UnitRPS,
+				Value:         fmt.Sprintf("%.1f", float64(numReq)/as.collectInterval.Seconds()),
+				Timestamp:     as.sclock.Now().UnixNano(),
+			}
+			as.logger.Debug("compute-throughput", lager.Data{"throughput": througput})
+
+			responseTime := &models.AppInstanceMetric{
+				AppId:         as.appId,
+				InstanceIndex: uint32(instanceIdx),
+				CollectedAt:   as.sclock.Now().UnixNano(),
+				Name:          models.MetricNameResponseTime,
+				Unit:          models.UnitMilliseconds,
+				Value:         fmt.Sprintf("%d", as.sumReponseTimes[instanceIdx]/(numReq*1000*1000)),
+				Timestamp:     as.sclock.Now().UnixNano(),
+			}
+			as.logger.Debug("compute-responsetime", lager.Data{"responsetime": responseTime})
+
+			err := as.database.SaveMetric(througput)
+			if err != nil {
+				as.logger.Error("save-metric-to-database", err, lager.Data{"throughput": througput})
+			}
+
+			err = as.database.SaveMetric(responseTime)
+			if err != nil {
+				as.logger.Error("save-metric-to-database", err, lager.Data{"responsetime": responseTime})
+			}
+
+		}
+	}
+
+	as.numRequests = make(map[int32]int64)
+	as.sumReponseTimes = make(map[int32]int64)
 }

--- a/src/autoscaler/metricscollector/collector/app_streamer_test.go
+++ b/src/autoscaler/metricscollector/collector/app_streamer_test.go
@@ -94,7 +94,7 @@ var _ = Describe("AppStreamer", func() {
 				}))
 
 			})
-			Context("when database fails", func() {
+			Context("when saving to database fails", func() {
 				BeforeEach(func() {
 					database.SaveMetricReturns(errors.New("an error"))
 				})
@@ -112,7 +112,7 @@ var _ = Describe("AppStreamer", func() {
 					msgChan <- noaa.NewHttpStartStopEnvelope(222222, 300000000, 600000000, 0)
 				}()
 
-				By("collecting and computing througput and responsetime for first interval")
+				By("collecting and computing throughput and responsetime for first interval")
 				Consistently(database.SaveMetricCallCount).Should(Equal(0))
 
 				By("save throughput and responsetime metric after the first collect interval")
@@ -144,7 +144,7 @@ var _ = Describe("AppStreamer", func() {
 					msgChan <- noaa.NewHttpStartStopEnvelope(666666, 300000000, 700000000, 1)
 				}()
 
-				By("collecting and computing througput and responsetime for second interval")
+				By("collecting and computing throughput and responsetime for second interval")
 				Consistently(database.SaveMetricCallCount).Should(Equal(2))
 
 				By("save throughput and responsetime metric after the second collect interval")
@@ -211,7 +211,7 @@ var _ = Describe("AppStreamer", func() {
 
 		})
 
-		Context("when there is no conatinermetrics or httpstartstop event", func() {
+		Context("when there is no containermetrics or httpstartstop event", func() {
 			BeforeEach(func() {
 				go func() {
 					eventType := events.Envelope_CounterEvent
@@ -219,6 +219,7 @@ var _ = Describe("AppStreamer", func() {
 				}()
 			})
 			It("Saves nothing to database", func() {
+				fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 				Consistently(database.SaveMetricCallCount).Should(BeZero())
 			})
 		})

--- a/src/autoscaler/metricscollector/collector/app_streamer_test.go
+++ b/src/autoscaler/metricscollector/collector/app_streamer_test.go
@@ -4,6 +4,7 @@ import (
 	"autoscaler/cf"
 	. "autoscaler/metricscollector/collector"
 	"autoscaler/metricscollector/fakes"
+	"autoscaler/metricscollector/noaa"
 	"autoscaler/models"
 
 	"code.cloudfoundry.org/clock/fakeclock"
@@ -20,26 +21,26 @@ import (
 var _ = Describe("AppStreamer", func() {
 
 	var (
-		cfc      *fakes.FakeCfClient
-		noaa     *fakes.FakeNoaaConsumer
-		database *fakes.FakeInstanceMetricsDB
-		streamer AppStreamer
-		buffer   *gbytes.Buffer
-		msgChan  chan *events.Envelope
-		errChan  chan error
-		fclock   *fakeclock.FakeClock
+		cfc          *fakes.FakeCfClient
+		noaaConsumer *fakes.FakeNoaaConsumer
+		database     *fakes.FakeInstanceMetricsDB
+		streamer     AppStreamer
+		buffer       *gbytes.Buffer
+		msgChan      chan *events.Envelope
+		errChan      chan error
+		fclock       *fakeclock.FakeClock
 	)
 
 	BeforeEach(func() {
 		cfc = &fakes.FakeCfClient{}
-		noaa = &fakes.FakeNoaaConsumer{}
+		noaaConsumer = &fakes.FakeNoaaConsumer{}
 		database = &fakes.FakeInstanceMetricsDB{}
 
 		logger := lagertest.NewTestLogger("AppStreamer-test")
 		buffer = logger.Buffer()
 		fclock = fakeclock.NewFakeClock(time.Now())
 
-		streamer = NewAppStreamer(logger, "an-app-id", cfc, noaa, database, fclock)
+		streamer = NewAppStreamer(logger, "an-app-id", TestCollectInterval, cfc, noaaConsumer, database, fclock)
 
 		msgChan = make(chan *events.Envelope)
 		errChan = make(chan error, 1)
@@ -57,7 +58,7 @@ var _ = Describe("AppStreamer", func() {
 
 		BeforeEach(func() {
 			cfc.GetTokensReturns(cf.Tokens{AccessToken: "test-access-token"})
-			noaa.StreamStub = func(appId string, authToken string) (outputChan <-chan *events.Envelope, errorChan <-chan error) {
+			noaaConsumer.StreamStub = func(appId string, authToken string) (outputChan <-chan *events.Envelope, errorChan <-chan error) {
 				Expect(appId).To(Equal("an-app-id"))
 				Expect(authToken).To(Equal("test-access-token"))
 				return msgChan, errChan
@@ -67,8 +68,8 @@ var _ = Describe("AppStreamer", func() {
 		Context("when there are containermetric events", func() {
 			BeforeEach(func() {
 				go func() {
-					msgChan <- models.NewContainerEnvelope(111111, "an-app-id", 0, 12.8, 12345678, 987654321)
-					msgChan <- models.NewContainerEnvelope(222222, "an-app-id", 1, 12.8, 23563212, 987654321)
+					msgChan <- noaa.NewContainerEnvelope(111111, "an-app-id", 0, 12.8, 12345678, 987654321)
+					msgChan <- noaa.NewContainerEnvelope(222222, "an-app-id", 1, 12.8, 23563212, 987654321)
 				}()
 			})
 			It("Saves metrics to database", func() {
@@ -93,7 +94,7 @@ var _ = Describe("AppStreamer", func() {
 				}))
 
 			})
-			Context("when save metrics to database fails", func() {
+			Context("when database fails", func() {
 				BeforeEach(func() {
 					database.SaveMetricReturns(errors.New("an error"))
 				})
@@ -102,10 +103,115 @@ var _ = Describe("AppStreamer", func() {
 					Eventually(buffer).Should(gbytes.Say("an error"))
 				})
 			})
+		})
+
+		Context("when there are httpstartstop events", func() {
+			It("Saves metrics to database with the given time interval", func() {
+				go func() {
+					msgChan <- noaa.NewHttpStartStopEnvelope(111111, 100000000, 200000000, 0)
+					msgChan <- noaa.NewHttpStartStopEnvelope(222222, 300000000, 600000000, 0)
+				}()
+
+				By("collecting and computing througput and responsetime for first interval")
+				Consistently(database.SaveMetricCallCount).Should(Equal(0))
+
+				By("save throughput and responsetime metric after the first collect interval")
+				fclock.WaitForWatcherAndIncrement(TestCollectInterval)
+				Eventually(database.SaveMetricCallCount).Should(Equal(2))
+
+				Expect(database.SaveMetricArgsForCall(0)).To(Equal(&models.AppInstanceMetric{
+					AppId:         "an-app-id",
+					InstanceIndex: 0,
+					CollectedAt:   fclock.Now().UnixNano(),
+					Name:          models.MetricNameThroughput,
+					Unit:          models.UnitRPS,
+					Value:         "2.0",
+					Timestamp:     fclock.Now().UnixNano(),
+				}))
+				Expect(database.SaveMetricArgsForCall(1)).To(Equal(&models.AppInstanceMetric{
+					AppId:         "an-app-id",
+					InstanceIndex: 0,
+					CollectedAt:   fclock.Now().UnixNano(),
+					Name:          models.MetricNameResponseTime,
+					Unit:          models.UnitMilliseconds,
+					Value:         "200",
+					Timestamp:     fclock.Now().UnixNano(),
+				}))
+
+				go func() {
+					msgChan <- noaa.NewHttpStartStopEnvelope(333333, 100000000, 300000000, 1)
+					msgChan <- noaa.NewHttpStartStopEnvelope(555555, 300000000, 600000000, 1)
+					msgChan <- noaa.NewHttpStartStopEnvelope(666666, 300000000, 700000000, 1)
+				}()
+
+				By("collecting and computing througput and responsetime for second interval")
+				Consistently(database.SaveMetricCallCount).Should(Equal(2))
+
+				By("save throughput and responsetime metric after the second collect interval")
+				fclock.Increment(TestCollectInterval)
+				Eventually(database.SaveMetricCallCount).Should(Equal(4))
+
+				Expect(database.SaveMetricArgsForCall(2)).To(Equal(&models.AppInstanceMetric{
+					AppId:         "an-app-id",
+					InstanceIndex: 1,
+					CollectedAt:   fclock.Now().UnixNano(),
+					Name:          models.MetricNameThroughput,
+					Unit:          models.UnitRPS,
+					Value:         "3.0",
+					Timestamp:     fclock.Now().UnixNano(),
+				}))
+				Expect(database.SaveMetricArgsForCall(3)).To(Equal(&models.AppInstanceMetric{
+					AppId:         "an-app-id",
+					InstanceIndex: 1,
+					CollectedAt:   fclock.Now().UnixNano(),
+					Name:          models.MetricNameResponseTime,
+					Unit:          models.UnitMilliseconds,
+					Value:         "300",
+					Timestamp:     fclock.Now().UnixNano(),
+				}))
+			})
+
+			Context("when the app has multiple instances", func() {
+				BeforeEach(func() {
+					go func() {
+						msgChan <- noaa.NewHttpStartStopEnvelope(111111, 100000000, 200000000, 0)
+						msgChan <- noaa.NewHttpStartStopEnvelope(222222, 300000000, 500000000, 1)
+						msgChan <- noaa.NewHttpStartStopEnvelope(333333, 200000000, 600000000, 2)
+						msgChan <- noaa.NewHttpStartStopEnvelope(555555, 300000000, 500000000, 2)
+					}()
+
+				})
+				It("saves throughput and responsetime metrics of multiple instances", func() {
+					Consistently(database.SaveMetricCallCount).Should(Equal(0))
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
+					Eventually(database.SaveMetricCallCount).Should(Equal(6))
+				})
+			})
+
+			Context("when database fails", func() {
+				BeforeEach(func() {
+					database.SaveMetricReturns(errors.New("an error"))
+					go func() {
+						msgChan <- noaa.NewHttpStartStopEnvelope(111111, 100000000, 200000000, 0)
+					}()
+				})
+				It("logs the errors", func() {
+					Consistently(database.SaveMetricCallCount).Should(Equal(0))
+
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
+					Eventually(buffer).Should(gbytes.Say("save-metric-to-database"))
+					Eventually(buffer).Should(gbytes.Say("an error"))
+					Eventually(buffer).Should(gbytes.Say("throughput"))
+
+					Eventually(buffer).Should(gbytes.Say("save-metric-to-database"))
+					Eventually(buffer).Should(gbytes.Say("an error"))
+					Eventually(buffer).Should(gbytes.Say("responsetime"))
+				})
+			})
 
 		})
 
-		Context("when there is no containermetric event", func() {
+		Context("when there is no conatinermetrics or httpstartstop event", func() {
 			BeforeEach(func() {
 				go func() {
 					eventType := events.Envelope_CounterEvent
@@ -141,7 +247,7 @@ var _ = Describe("AppStreamer", func() {
 		})
 		Context("when error occurs closing the connection", func() {
 			BeforeEach(func() {
-				noaa.CloseReturns(errors.New("an error"))
+				noaaConsumer.CloseReturns(errors.New("an error"))
 			})
 			It("logs the error", func() {
 				Eventually(buffer).Should(gbytes.Say("close-noaa-connections"))

--- a/src/autoscaler/metricscollector/collector/apppoller_test.go
+++ b/src/autoscaler/metricscollector/collector/apppoller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Apppoller", func() {
 		buffer = logger.Buffer()
 
 		fclock = fakeclock.NewFakeClock(time.Now())
-		poller = NewAppPoller(logger, "test-app-id", TestPollInterval, cfc, noaa, database, fclock)
+		poller = NewAppPoller(logger, "test-app-id", TestCollectInterval, cfc, noaa, database, fclock)
 		timestamp = 111111
 	})
 
@@ -56,10 +56,10 @@ var _ = Describe("Apppoller", func() {
 		It("polls metrics with the given interval", func() {
 			Eventually(noaa.ContainerEnvelopesCallCount).Should(Equal(1))
 
-			fclock.WaitForWatcherAndIncrement(TestPollInterval)
+			fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 			Eventually(noaa.ContainerEnvelopesCallCount).Should(Equal(2))
 
-			fclock.WaitForWatcherAndIncrement(TestPollInterval)
+			fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 			Eventually(noaa.ContainerEnvelopesCallCount).Should(Equal(3))
 		})
 
@@ -105,10 +105,10 @@ var _ = Describe("Apppoller", func() {
 				It("saves the metrics to database", func() {
 					Eventually(database.SaveMetricCallCount).Should(Equal(1))
 
-					fclock.WaitForWatcherAndIncrement(TestPollInterval)
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 					Eventually(database.SaveMetricCallCount).Should(Equal(2))
 
-					fclock.WaitForWatcherAndIncrement(TestPollInterval)
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 					Eventually(database.SaveMetricCallCount).Should(Equal(3))
 				})
 			})
@@ -126,10 +126,10 @@ var _ = Describe("Apppoller", func() {
 				It("saves nothing to database", func() {
 					Consistently(database.SaveMetricCallCount).Should(BeZero())
 
-					fclock.WaitForWatcherAndIncrement(TestPollInterval)
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 					Consistently(database.SaveMetricCallCount).Should(BeZero())
 
-					fclock.WaitForWatcherAndIncrement(TestPollInterval)
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 					Consistently(database.SaveMetricCallCount).Should(BeZero())
 				})
 
@@ -175,10 +175,10 @@ var _ = Describe("Apppoller", func() {
 				It("saves metrics in non-empty container envelops to database", func() {
 					Eventually(database.SaveMetricCallCount).Should(Equal(1))
 
-					fclock.WaitForWatcherAndIncrement(TestPollInterval)
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 					Consistently(database.SaveMetricCallCount).Should(Equal(1))
 
-					fclock.WaitForWatcherAndIncrement(TestPollInterval)
+					fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 					Eventually(database.SaveMetricCallCount).Should(Equal(2))
 				})
 			})
@@ -195,7 +195,7 @@ var _ = Describe("Apppoller", func() {
 				Eventually(buffer).Should(gbytes.Say("test apppoller error"))
 				Consistently(database.SaveMetricCallCount).Should(BeZero())
 
-				fclock.WaitForWatcherAndIncrement(TestPollInterval)
+				fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 				Eventually(buffer).Should(gbytes.Say("poll-metric-from-noaa"))
 				Eventually(buffer).Should(gbytes.Say("test apppoller error"))
 				Consistently(database.SaveMetricCallCount).Should(BeZero())
@@ -248,11 +248,11 @@ var _ = Describe("Apppoller", func() {
 		It("stops the polling", func() {
 			Eventually(noaa.ContainerEnvelopesCallCount).Should(Equal(1))
 
-			fclock.WaitForWatcherAndIncrement(TestPollInterval)
+			fclock.WaitForWatcherAndIncrement(TestCollectInterval)
 			Eventually(noaa.ContainerEnvelopesCallCount).Should(Equal(2))
 
 			poller.Stop()
-			fclock.Increment(TestPollInterval)
+			fclock.Increment(TestCollectInterval)
 			Consistently(noaa.ContainerEnvelopesCallCount).Should(Equal(2))
 		})
 	})

--- a/src/autoscaler/metricscollector/collector/collector_suite_test.go
+++ b/src/autoscaler/metricscollector/collector/collector_suite_test.go
@@ -10,8 +10,8 @@ import (
 
 // make sure TestPollInterval is less than TestRefreshInterval
 const (
-	TestPollInterval    time.Duration = 1 * time.Second
 	TestRefreshInterval time.Duration = 3 * time.Second
+	TestCollectInterval time.Duration = 1 * time.Second
 )
 
 func TestCollector(t *testing.T) {

--- a/src/autoscaler/metricscollector/config/config.go
+++ b/src/autoscaler/metricscollector/config/config.go
@@ -18,7 +18,7 @@ import (
 const (
 	DefaultLoggingLevel                  = "info"
 	DefaultRefreshInterval time.Duration = 60 * time.Second
-	DefaultPollInterval    time.Duration = 30 * time.Second
+	DefaultCollectInterval time.Duration = 30 * time.Second
 	DefaultLockTTL         time.Duration = locket.DefaultSessionTTL
 	DefaultRetryInterval   time.Duration = locket.RetryInterval
 )
@@ -51,12 +51,12 @@ type DbConfig struct {
 
 type CollectorConfig struct {
 	RefreshInterval time.Duration `yaml:"refresh_interval"`
-	PollInterval    time.Duration `yaml:"poll_interval"`
+	CollectInterval time.Duration `yaml:"collect_interval"`
 }
 
 var defaultCollectorConfig = CollectorConfig{
 	RefreshInterval: DefaultRefreshInterval,
-	PollInterval:    DefaultPollInterval,
+	CollectInterval: DefaultCollectInterval,
 }
 
 type LockConfig struct {

--- a/src/autoscaler/metricscollector/config/config.go
+++ b/src/autoscaler/metricscollector/config/config.go
@@ -118,6 +118,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: InstanceMetrics DB url is empty")
 	}
 
+	if c.Collector.CollectInterval == time.Duration(0) {
+		return fmt.Errorf("Configuration error: CollectInterval is 0")
+	}
+
+	if c.Collector.RefreshInterval == time.Duration(0) {
+		return fmt.Errorf("Configuration error: RefreshInterval is 0")
+	}
+
 	return nil
 
 }

--- a/src/autoscaler/metricscollector/config/config_test.go
+++ b/src/autoscaler/metricscollector/config/config_test.go
@@ -61,7 +61,7 @@ server:
 				configBytes = []byte(`
 collector:
   refresh_interval: 20a
-  poll_interval: 10s  
+  collect_interval: 10s  
 `)
 			})
 
@@ -93,7 +93,7 @@ db:
   instance_metrics_db_url: postgres://pqgotest:password@localhost/pqgotest
 collector:
   refresh_interval: 20s
-  poll_interval: 10s
+  collect_interval: 10s
 lock:
   lock_ttl: 15s
   lock_retry_interval: 10s
@@ -119,7 +119,7 @@ lock:
 				Expect(conf.Db.InstanceMetricsDbUrl).To(Equal("postgres://pqgotest:password@localhost/pqgotest"))
 
 				Expect(conf.Collector.RefreshInterval).To(Equal(20 * time.Second))
-				Expect(conf.Collector.PollInterval).To(Equal(10 * time.Second))
+				Expect(conf.Collector.CollectInterval).To(Equal(10 * time.Second))
 
 				Expect(conf.Server.TLS.KeyFile).To(Equal("/var/vcap/jobs/autoscaler/config/certs/server.key"))
 				Expect(conf.Server.TLS.CertFile).To(Equal("/var/vcap/jobs/autoscaler/config/certs/server.crt"))
@@ -149,7 +149,7 @@ db:
 				Expect(conf.Server.Port).To(Equal(8080))
 				Expect(conf.Logging.Level).To(Equal(DefaultLoggingLevel))
 				Expect(conf.Collector.RefreshInterval).To(Equal(DefaultRefreshInterval))
-				Expect(conf.Collector.PollInterval).To(Equal(DefaultPollInterval))
+				Expect(conf.Collector.CollectInterval).To(Equal(DefaultCollectInterval))
 
 				Expect(conf.Lock.LockRetryInterval).To(Equal(DefaultRetryInterval))
 				Expect(conf.Lock.LockTTL).To(Equal(DefaultLockTTL))

--- a/src/autoscaler/metricscollector/config/config_test.go
+++ b/src/autoscaler/metricscollector/config/config_test.go
@@ -167,6 +167,8 @@ db:
 			conf.Db.PolicyDbUrl = "postgres://pqgotest:password@exampl.com/pqgotest"
 			conf.Db.InstanceMetricsDbUrl = "postgres://pqgotest:password@exampl.com/pqgotest"
 			conf.Lock.ConsulClusterConfig = "http://127.0.0.1:8500"
+			conf.Collector.CollectInterval = time.Duration(30 * time.Second)
+			conf.Collector.RefreshInterval = time.Duration(60 * time.Second)
 		})
 
 		JustBeforeEach(func() {
@@ -190,7 +192,6 @@ db:
 		})
 
 		Context("when policy db url is not set", func() {
-
 			BeforeEach(func() {
 				conf.Db.PolicyDbUrl = ""
 			})
@@ -201,13 +202,32 @@ db:
 		})
 
 		Context("when metrics db url is not set", func() {
-
 			BeforeEach(func() {
 				conf.Db.InstanceMetricsDbUrl = ""
 			})
 
 			It("should error", func() {
 				Expect(err).To(MatchError(MatchRegexp("Configuration error: InstanceMetrics DB url is empty")))
+			})
+		})
+
+		Context("when collect interval is 0", func() {
+			BeforeEach(func() {
+				conf.Collector.CollectInterval = time.Duration(0)
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: CollectInterval is 0")))
+			})
+		})
+
+		Context("when refresh interval is 0", func() {
+			BeforeEach(func() {
+				conf.Collector.RefreshInterval = time.Duration(0)
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: RefreshInterval is 0")))
 			})
 		})
 

--- a/src/autoscaler/metricscollector/exampleconfig/example.yml
+++ b/src/autoscaler/metricscollector/exampleconfig/example.yml
@@ -11,8 +11,8 @@ db:
   policy_db_url: postgres://postgres:postgres@localhost/autoscaler?sslmode=disable
   instance_metrics_db_url: postgres://postgres:postgres@localhost/autoscaler?sslmode=disable
 collector:
-  refresh_interval: 60s
-  poll_interval: 10s
+  refresh_interval: 30s
+  collect_interval: 10s
 # lock:
 #   lock_ttl: 15s
 #   lock_retry_interval: 10s

--- a/src/autoscaler/metricscollector/fakes/fake_app_collector.go
+++ b/src/autoscaler/metricscollector/fakes/fake_app_collector.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-type FakeAppPoller struct {
+type FakeAppCollector struct {
 	StartStub        func()
 	startMutex       sync.RWMutex
 	startArgsForCall []struct{}
@@ -17,7 +17,7 @@ type FakeAppPoller struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAppPoller) Start() {
+func (fake *FakeAppCollector) Start() {
 	fake.startMutex.Lock()
 	fake.startArgsForCall = append(fake.startArgsForCall, struct{}{})
 	fake.recordInvocation("Start", []interface{}{})
@@ -27,13 +27,13 @@ func (fake *FakeAppPoller) Start() {
 	}
 }
 
-func (fake *FakeAppPoller) StartCallCount() int {
+func (fake *FakeAppCollector) StartCallCount() int {
 	fake.startMutex.RLock()
 	defer fake.startMutex.RUnlock()
 	return len(fake.startArgsForCall)
 }
 
-func (fake *FakeAppPoller) Stop() {
+func (fake *FakeAppCollector) Stop() {
 	fake.stopMutex.Lock()
 	fake.stopArgsForCall = append(fake.stopArgsForCall, struct{}{})
 	fake.recordInvocation("Stop", []interface{}{})
@@ -43,13 +43,13 @@ func (fake *FakeAppPoller) Stop() {
 	}
 }
 
-func (fake *FakeAppPoller) StopCallCount() int {
+func (fake *FakeAppCollector) StopCallCount() int {
 	fake.stopMutex.RLock()
 	defer fake.stopMutex.RUnlock()
 	return len(fake.stopArgsForCall)
 }
 
-func (fake *FakeAppPoller) Invocations() map[string][][]interface{} {
+func (fake *FakeAppCollector) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.startMutex.RLock()
@@ -59,7 +59,7 @@ func (fake *FakeAppPoller) Invocations() map[string][][]interface{} {
 	return fake.invocations
 }
 
-func (fake *FakeAppPoller) recordInvocation(key string, args []interface{}) {
+func (fake *FakeAppCollector) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -71,4 +71,4 @@ func (fake *FakeAppPoller) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ collector.AppPoller = new(FakeAppPoller)
+var _ collector.AppCollector = new(FakeAppCollector)

--- a/src/autoscaler/metricscollector/fakes/fakes.go
+++ b/src/autoscaler/metricscollector/fakes/fakes.go
@@ -5,4 +5,4 @@ package fakes
 //go:generate counterfeiter -o ./fake_policy_db.go ../../db PolicyDB
 //go:generate counterfeiter -o ./fake_instancemetrics_db.go ../../db InstanceMetricsDB
 //go:generate counterfeiter -o ./fake_appmetrics_db.go ../../db AppMetricDB
-//go:generate counterfeiter -o ./fake_app_poller.go ../collector AppPoller
+//go:generate counterfeiter -o ./fake_app_collector.go ../collector AppCollector

--- a/src/autoscaler/metricscollector/noaa/app_events.go
+++ b/src/autoscaler/metricscollector/noaa/app_events.go
@@ -1,0 +1,62 @@
+package noaa
+
+import (
+	"autoscaler/models"
+	"fmt"
+	"github.com/cloudfoundry/sonde-go/events"
+)
+
+func NewContainerEnvelope(timestamp int64, appId string, index int32, cpu float64, memory uint64, disk uint64) *events.Envelope {
+	eventType := events.Envelope_ContainerMetric
+	return &events.Envelope{
+		EventType: &eventType,
+		Timestamp: &timestamp,
+		ContainerMetric: &events.ContainerMetric{
+			ApplicationId: &appId,
+			InstanceIndex: &index,
+			CpuPercentage: &cpu,
+			MemoryBytes:   &memory,
+			DiskBytes:     &disk,
+		},
+	}
+}
+
+func NewHttpStartStopEnvelope(timestamp, startTime, stopTime int64, instanceIdx int32) *events.Envelope {
+	eventType := events.Envelope_HttpStartStop
+	return &events.Envelope{
+		EventType: &eventType,
+		Timestamp: &timestamp,
+		HttpStartStop: &events.HttpStartStop{
+			StartTimestamp: &startTime,
+			StopTimestamp:  &stopTime,
+			InstanceIndex:  &instanceIdx,
+		},
+	}
+}
+
+func GetInstanceMemoryMetricFromContainerEnvelopes(collectAt int64, appId string, containerEnvelopes []*events.Envelope) []*models.AppInstanceMetric {
+	metrics := []*models.AppInstanceMetric{}
+	for _, event := range containerEnvelopes {
+		instanceMetric := GetInstanceMemoryMetricFromContainerMetricEvent(collectAt, appId, event)
+		if instanceMetric != nil {
+			metrics = append(metrics, instanceMetric)
+		}
+	}
+	return metrics
+}
+
+func GetInstanceMemoryMetricFromContainerMetricEvent(collectAt int64, appId string, event *events.Envelope) *models.AppInstanceMetric {
+	cm := event.GetContainerMetric()
+	if (cm != nil) && (*cm.ApplicationId == appId) {
+		return &models.AppInstanceMetric{
+			AppId:         appId,
+			InstanceIndex: uint32(cm.GetInstanceIndex()),
+			CollectedAt:   collectAt,
+			Name:          models.MetricNameMemory,
+			Unit:          models.UnitMegaBytes,
+			Value:         fmt.Sprintf("%d", int(float64(cm.GetMemoryBytes())/(1024*1024)+0.5)),
+			Timestamp:     event.GetTimestamp(),
+		}
+	}
+	return nil
+}

--- a/src/autoscaler/metricscollector/noaa/app_events_test.go
+++ b/src/autoscaler/metricscollector/noaa/app_events_test.go
@@ -1,18 +1,19 @@
-package models_test
+package noaa_test
 
 import (
-	. "autoscaler/models"
+	. "autoscaler/metricscollector/noaa"
+	"autoscaler/models"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Metrics", func() {
+var _ = Describe("AppEvents", func() {
 	Describe("GetInstanceMemoryMetricFromContainerMetricsEvent", func() {
 		var (
 			event  *events.Envelope
-			metric *AppInstanceMetric
+			metric *models.AppInstanceMetric
 		)
 		JustBeforeEach(func() {
 			metric = GetInstanceMemoryMetricFromContainerMetricEvent(123456, "an-app-id", event)
@@ -23,12 +24,12 @@ var _ = Describe("Metrics", func() {
 				event = NewContainerEnvelope(111111, "an-app-id", 0, 12.11, 88623692, 233300000)
 			})
 			It("returns the memory metric", func() {
-				Expect(metric).To(Equal(&AppInstanceMetric{
+				Expect(metric).To(Equal(&models.AppInstanceMetric{
 					AppId:         "an-app-id",
 					InstanceIndex: 0,
 					CollectedAt:   123456,
-					Name:          MetricNameMemory,
-					Unit:          UnitMegaBytes,
+					Name:          models.MetricNameMemory,
+					Unit:          models.UnitMegaBytes,
 					Value:         "85",
 					Timestamp:     111111,
 				}))
@@ -59,7 +60,7 @@ var _ = Describe("Metrics", func() {
 	Describe("GetInstanceMemoryMetricFromContainerEnvelopes", func() {
 		var (
 			containerEnvelops []*events.Envelope
-			metrics           []*AppInstanceMetric
+			metrics           []*models.AppInstanceMetric
 		)
 
 		JustBeforeEach(func() {
@@ -101,21 +102,21 @@ var _ = Describe("Metrics", func() {
 
 			It("should return instance memory metrics from given app", func() {
 				Expect(metrics).To(ConsistOf(
-					&AppInstanceMetric{
+					&models.AppInstanceMetric{
 						AppId:         "an-app-id",
 						InstanceIndex: 0,
 						CollectedAt:   123456,
-						Name:          MetricNameMemory,
-						Unit:          UnitMegaBytes,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitMegaBytes,
 						Value:         "1",
 						Timestamp:     111111,
 					},
-					&AppInstanceMetric{
+					&models.AppInstanceMetric{
 						AppId:         "an-app-id",
 						InstanceIndex: 1,
 						CollectedAt:   123456,
-						Name:          MetricNameMemory,
-						Unit:          UnitMegaBytes,
+						Name:          models.MetricNameMemory,
+						Unit:          models.UnitMegaBytes,
 						Value:         "85",
 						Timestamp:     333333,
 					},

--- a/src/autoscaler/metricscollector/noaa/noaa_suite_test.go
+++ b/src/autoscaler/metricscollector/noaa/noaa_suite_test.go
@@ -1,0 +1,13 @@
+package noaa_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestNoaa(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Noaa Suite")
+}

--- a/src/autoscaler/metricscollector/server/metric_handler.go
+++ b/src/autoscaler/metricscollector/server/metric_handler.go
@@ -49,7 +49,7 @@ func (h *MetricHandler) GetMemoryMetric(w http.ResponseWriter, r *http.Request, 
 	}
 	h.logger.Debug("Get-memory-metric-from-noaa", lager.Data{"appId": appId, "containerEnvelopes": containerEnvelopes})
 
-	metrics := models.GetInstanceMemoryMetricFromContainerEnvelopes(time.Now().UnixNano(), appId, containerEnvelopes)
+	metrics := noaa.GetInstanceMemoryMetricFromContainerEnvelopes(time.Now().UnixNano(), appId, containerEnvelopes)
 	var body []byte
 	body, err = json.Marshal(metrics)
 	if err != nil {

--- a/src/autoscaler/models/metrics.go
+++ b/src/autoscaler/models/metrics.go
@@ -1,11 +1,5 @@
 package models
 
-import (
-	"fmt"
-
-	"github.com/cloudfoundry/sonde-go/events"
-)
-
 const (
 	UnitPercentage   = "percentage"
 	UnitMegaBytes    = "megabytes"
@@ -15,6 +9,8 @@ const (
 )
 
 const MetricNameMemory = "memoryused"
+const MetricNameThroughput = "throughput"
+const MetricNameResponseTime = "responsetime"
 
 type AppInstanceMetric struct {
 	AppId         string `json:"app_id"`
@@ -24,46 +20,4 @@ type AppInstanceMetric struct {
 	Unit          string `json:"unit"`
 	Value         string `json:"value"`
 	Timestamp     int64  `json:"timestamp"`
-}
-
-func NewContainerEnvelope(timestamp int64, appId string, index int32, cpu float64, memory uint64, disk uint64) *events.Envelope {
-	eventType := events.Envelope_ContainerMetric
-	return &events.Envelope{
-		EventType: &eventType,
-		Timestamp: &timestamp,
-		ContainerMetric: &events.ContainerMetric{
-			ApplicationId: &appId,
-			InstanceIndex: &index,
-			CpuPercentage: &cpu,
-			MemoryBytes:   &memory,
-			DiskBytes:     &disk,
-		},
-	}
-}
-
-func GetInstanceMemoryMetricFromContainerEnvelopes(collectAt int64, appId string, containerEnvelopes []*events.Envelope) []*AppInstanceMetric {
-	metrics := []*AppInstanceMetric{}
-	for _, event := range containerEnvelopes {
-		instanceMetric := GetInstanceMemoryMetricFromContainerMetricEvent(collectAt, appId, event)
-		if instanceMetric != nil {
-			metrics = append(metrics, instanceMetric)
-		}
-	}
-	return metrics
-}
-
-func GetInstanceMemoryMetricFromContainerMetricEvent(collectAt int64, appId string, event *events.Envelope) *AppInstanceMetric {
-	cm := event.GetContainerMetric()
-	if (cm != nil) && (*cm.ApplicationId == appId) {
-		return &AppInstanceMetric{
-			AppId:         appId,
-			InstanceIndex: uint32(cm.GetInstanceIndex()),
-			CollectedAt:   collectAt,
-			Name:          MetricNameMemory,
-			Unit:          UnitMegaBytes,
-			Value:         fmt.Sprintf("%d", int(float64(cm.GetMemoryBytes())/(1024*1024)+0.5)),
-			Timestamp:     event.GetTimestamp(),
-		}
-	}
-	return nil
 }

--- a/src/integration/components.go
+++ b/src/integration/components.go
@@ -304,7 +304,7 @@ spring.data.jpa.repositories.enabled=false
 	return cfgFile.Name()
 }
 
-func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port int, ccNOAAUAAUrl string, cfGrantTypePassword string, pollInterval time.Duration,
+func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port int, ccNOAAUAAUrl string, cfGrantTypePassword string, collectInterval time.Duration,
 	refreshInterval time.Duration, tmpDir string, lockTTL time.Duration, lockRetryInterval time.Duration, ConsulClusterConfig string) string {
 	cfg := mcConfig.Config{
 		Cf: cf.CfConfig{
@@ -329,7 +329,7 @@ func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port i
 			PolicyDbUrl:          dbUri,
 		},
 		Collector: mcConfig.CollectorConfig{
-			PollInterval:    pollInterval,
+			CollectInterval: collectInterval,
 			RefreshInterval: refreshInterval,
 		},
 		Lock: mcConfig.LockConfig{

--- a/src/integration/integration_metricscollector_eventgenerator_scalingengine_test.go
+++ b/src/integration/integration_metricscollector_eventgenerator_scalingengine_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Integration_Metricscollector_Eventgenerator_Scalingengine", fu
 		testAppId = getRandomId()
 		startFakeCCNOAAUAA(initInstanceCount)
 		fakeMetrics(testAppId, 400*1024*1024)
-		metricsCollectorConfPath = components.PrepareMetricsCollectorConfig(dbUrl, components.Ports[MetricsCollector], fakeCCNOAAUAA.URL(), cf.GrantTypePassword, pollInterval,
+		metricsCollectorConfPath = components.PrepareMetricsCollectorConfig(dbUrl, components.Ports[MetricsCollector], fakeCCNOAAUAA.URL(), cf.GrantTypePassword, collectInterval,
 			refreshInterval, tmpDir, locket.DefaultSessionTTL, locket.RetryInterval, consulRunner.ConsulCluster())
 		eventGeneratorConfPath = components.PrepareEventGeneratorConfig(dbUrl, fmt.Sprintf("https://127.0.0.1:%d", components.Ports[MetricsCollector]), fmt.Sprintf("https://127.0.0.1:%d", components.Ports[ScalingEngine]), aggregatorExecuteInterval, policyPollerInterval, evaluationManagerInterval, tmpDir, locket.DefaultSessionTTL, locket.RetryInterval, consulRunner.ConsulCluster())
 		scalingEngineConfPath = components.PrepareScalingEngineConfig(dbUrl, components.Ports[ScalingEngine], fakeCCNOAAUAA.URL(), cf.GrantTypePassword, tmpDir, consulRunner.ConsulCluster())

--- a/src/integration/integration_suite_test.go
+++ b/src/integration/integration_suite_test.go
@@ -67,7 +67,7 @@ var (
 	apiSchedulerHttpRequestTimeout           time.Duration = 5 * time.Second
 	schedulerScalingEngineHttpRequestTimeout time.Duration = 10 * time.Second
 
-	pollInterval              time.Duration = 1 * time.Second
+	collectInterval           time.Duration = 1 * time.Second
 	refreshInterval           time.Duration = 1 * time.Second
 	aggregatorExecuteInterval time.Duration = 1 * time.Second
 	policyPollerInterval      time.Duration = 1 * time.Second


### PR DESCRIPTION
[#144498253]

The app streamer is not enabled in main.go yet, will have another PR to enable the switch to streaming mode, and end-to-end response time/throughput based scaling 