### PR TITLE
Scaling history could be retrieved from scaling engine with given ord…

### DIFF
--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -12,6 +12,10 @@ const (
 	DESC OrderType = iota
 	ASC
 )
+const (
+	DESCSTR string = "DESC"
+	ASCSTR  string = "ASC"
+)
 
 type InstanceMetricsDB interface {
 	RetrieveInstanceMetrics(appid string, name string, start int64, end int64) ([]*models.AppInstanceMetric, error)

--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -29,7 +29,7 @@ type AppMetricDB interface {
 
 type ScalingEngineDB interface {
 	SaveScalingHistory(history *models.AppScalingHistory) error
-	RetrieveScalingHistories(appId string, start int64, end int64) ([]*models.AppScalingHistory, error)
+	RetrieveScalingHistories(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error)
 	PruneScalingHistories(before int64) error
 	UpdateScalingCooldownExpireTime(appId string, expireAt int64) error
 	CanScaleApp(appId string) (bool, error)

--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -6,6 +6,13 @@ import (
 
 const PostgresDriverName = "postgres"
 
+type OrderType uint8
+
+const (
+	DESC OrderType = iota
+	ASC
+)
+
 type InstanceMetricsDB interface {
 	RetrieveInstanceMetrics(appid string, name string, start int64, end int64) ([]*models.AppInstanceMetric, error)
 	SaveMetric(metric *models.AppInstanceMetric) error
@@ -29,7 +36,7 @@ type AppMetricDB interface {
 
 type ScalingEngineDB interface {
 	SaveScalingHistory(history *models.AppScalingHistory) error
-	RetrieveScalingHistories(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error)
+	RetrieveScalingHistories(appId string, start int64, end int64, orderType OrderType) ([]*models.AppScalingHistory, error)
 	PruneScalingHistories(before int64) error
 	UpdateScalingCooldownExpireTime(appId string, expireAt int64) error
 	CanScaleApp(appId string) (bool, error)

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb.go
@@ -60,11 +60,17 @@ func (sdb *ScalingEngineSQLDB) SaveScalingHistory(history *models.AppScalingHist
 	return err
 }
 
-func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int64, end int64) ([]*models.AppScalingHistory, error) {
+func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error) {
+	var orderBy string
+	if order == 0 {
+		orderBy = "DESC"
+	} else {
+		orderBy = "ASC"
+	}
 	query := "SELECT timestamp, scalingtype, status, oldinstances, newinstances, reason, message, error FROM scalinghistory WHERE" +
 		" appid = $1 " +
 		" AND timestamp >= $2" +
-		" AND timestamp <= $3 ORDER BY timestamp"
+		" AND timestamp <= $3 ORDER BY timestamp " + orderBy
 
 	if end < 0 {
 		end = time.Now().UnixNano()
@@ -74,7 +80,7 @@ func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int6
 	rows, err := sdb.sqldb.Query(query, appId, start, end)
 	if err != nil {
 		sdb.logger.Error("retrieve-scaling-histories", err,
-			lager.Data{"query": query, "appid": appId, "start": start, "end": end})
+			lager.Data{"query": query, "appid": appId, "start": start, "end": end, "order": order})
 		return nil, err
 	}
 

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb.go
@@ -63,9 +63,9 @@ func (sdb *ScalingEngineSQLDB) SaveScalingHistory(history *models.AppScalingHist
 func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int64, end int64, orderType db.OrderType) ([]*models.AppScalingHistory, error) {
 	var orderStr string
 	if orderType == db.DESC {
-		orderStr = "DESC"
+		orderStr = db.DESCSTR
 	} else {
-		orderStr = "ASC"
+		orderStr = db.ASCSTR
 	}
 	query := "SELECT timestamp, scalingtype, status, oldinstances, newinstances, reason, message, error FROM scalinghistory WHERE" +
 		" appid = $1 " +

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb.go
@@ -60,17 +60,17 @@ func (sdb *ScalingEngineSQLDB) SaveScalingHistory(history *models.AppScalingHist
 	return err
 }
 
-func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error) {
-	var orderBy string
-	if order == 0 {
-		orderBy = "DESC"
+func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int64, end int64, orderType db.OrderType) ([]*models.AppScalingHistory, error) {
+	var orderStr string
+	if orderType == db.DESC {
+		orderStr = "DESC"
 	} else {
-		orderBy = "ASC"
+		orderStr = "ASC"
 	}
 	query := "SELECT timestamp, scalingtype, status, oldinstances, newinstances, reason, message, error FROM scalinghistory WHERE" +
 		" appid = $1 " +
 		" AND timestamp >= $2" +
-		" AND timestamp <= $3 ORDER BY timestamp " + orderBy
+		" AND timestamp <= $3 ORDER BY timestamp " + orderStr
 
 	if end < 0 {
 		end = time.Now().UnixNano()
@@ -80,7 +80,7 @@ func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int6
 	rows, err := sdb.sqldb.Query(query, appId, start, end)
 	if err != nil {
 		sdb.logger.Error("retrieve-scaling-histories", err,
-			lager.Data{"query": query, "appid": appId, "start": start, "end": end, "order": order})
+			lager.Data{"query": query, "appid": appId, "start": start, "end": end, "orderType": orderType})
 		return nil, err
 	}
 

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb_test.go
@@ -22,6 +22,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 		history        *models.AppScalingHistory
 		start          int64
 		end            int64
+		order          int64
 		appId          string
 		histories      []*models.AppScalingHistory
 		canScale       bool
@@ -147,6 +148,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			start = 0
 			end = -1
 			appId = "an-app-id"
+			order = 0
 		})
 
 		AfterEach(func() {
@@ -191,7 +193,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			err = sdb.SaveScalingHistory(history)
 			Expect(err).NotTo(HaveOccurred())
 
-			histories, err = sdb.RetrieveScalingHistories(appId, start, end)
+			histories, err = sdb.RetrieveScalingHistories(appId, start, end, order)
 		})
 
 		Context("When the app has no hisotry", func() {
@@ -257,8 +259,11 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			})
 		})
 
-		Context("when retrieving all the histories( start = 0, end = -1) ", func() {
-			It("returns all the histories of the app ordered by timestamp", func() {
+		Context("when retrieving all the histories( start = 0, end = -1, order = 1) ", func() {
+			BeforeEach(func() {
+				order = 1
+			})
+			It("returns all the histories of the app ordered by timestamp asc", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(histories).To(Equal([]*models.AppScalingHistory{
 					&models.AppScalingHistory{
@@ -306,20 +311,18 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			})
 		})
 
-		Context("When retrieving part of the histories", func() {
+		Context("when retrieving all the histories( start = 0, end = -1, order = 0) ", func() {
 			BeforeEach(func() {
-				start = 333333
-				end = 555566
+				order = 0
 			})
-
-			It("return correct histories", func() {
+			It("returns all the histories of the app ordered by timestamp desc", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(histories).To(Equal([]*models.AppScalingHistory{
 					&models.AppScalingHistory{
 						AppId:        "an-app-id",
-						Timestamp:    333333,
-						ScalingType:  models.ScalingTypeSchedule,
-						Status:       models.ScalingStatusIgnored,
+						Timestamp:    666666,
+						ScalingType:  models.ScalingTypeDynamic,
+						Status:       models.ScalingStatusSucceeded,
 						OldInstances: 2,
 						NewInstances: 4,
 						Reason:       "a reason",
@@ -335,6 +338,63 @@ var _ = Describe("ScalingEngineSqldb", func() {
 						Reason:       "a reason",
 						Message:      "a message",
 						Error:        "an error",
+					},
+					&models.AppScalingHistory{
+						AppId:        "an-app-id",
+						Timestamp:    333333,
+						ScalingType:  models.ScalingTypeSchedule,
+						Status:       models.ScalingStatusIgnored,
+						OldInstances: 2,
+						NewInstances: 4,
+						Reason:       "a reason",
+						Message:      "a message",
+					},
+					&models.AppScalingHistory{
+						AppId:        "an-app-id",
+						Timestamp:    222222,
+						ScalingType:  models.ScalingTypeDynamic,
+						Status:       models.ScalingStatusFailed,
+						OldInstances: 2,
+						NewInstances: 4,
+						Reason:       "a reason",
+						Message:      "a message",
+						Error:        "an error",
+					},
+				}))
+			})
+		})
+
+		Context("When retrieving part of the histories", func() {
+			BeforeEach(func() {
+				start = 333333
+				end = 555566
+				order = 0
+
+			})
+
+			It("return correct histories", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(histories).To(Equal([]*models.AppScalingHistory{
+
+					&models.AppScalingHistory{
+						AppId:        "an-app-id",
+						Timestamp:    555555,
+						ScalingType:  models.ScalingTypeSchedule,
+						Status:       models.ScalingStatusFailed,
+						OldInstances: 2,
+						NewInstances: 4,
+						Reason:       "a reason",
+						Message:      "a message",
+						Error:        "an error",
+					}, &models.AppScalingHistory{
+						AppId:        "an-app-id",
+						Timestamp:    333333,
+						ScalingType:  models.ScalingTypeSchedule,
+						Status:       models.ScalingStatusIgnored,
+						OldInstances: 2,
+						NewInstances: 4,
+						Reason:       "a reason",
+						Message:      "a message",
 					}}))
 
 			})

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb_test.go
@@ -1,6 +1,7 @@
 package sqldb_test
 
 import (
+	"autoscaler/db"
 	. "autoscaler/db/sqldb"
 	"autoscaler/models"
 
@@ -22,7 +23,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 		history        *models.AppScalingHistory
 		start          int64
 		end            int64
-		order          int64
+		orderType      db.OrderType
 		appId          string
 		histories      []*models.AppScalingHistory
 		canScale       bool
@@ -148,7 +149,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			start = 0
 			end = -1
 			appId = "an-app-id"
-			order = 0
+			orderType = db.DESC
 		})
 
 		AfterEach(func() {
@@ -193,7 +194,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			err = sdb.SaveScalingHistory(history)
 			Expect(err).NotTo(HaveOccurred())
 
-			histories, err = sdb.RetrieveScalingHistories(appId, start, end, order)
+			histories, err = sdb.RetrieveScalingHistories(appId, start, end, orderType)
 		})
 
 		Context("When the app has no hisotry", func() {
@@ -259,9 +260,9 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			})
 		})
 
-		Context("when retrieving all the histories( start = 0, end = -1, order = 1) ", func() {
+		Context("when retrieving all the histories( start = 0, end = -1, orderType = ASC) ", func() {
 			BeforeEach(func() {
-				order = 1
+				orderType = db.ASC
 			})
 			It("returns all the histories of the app ordered by timestamp asc", func() {
 				Expect(err).NotTo(HaveOccurred())
@@ -311,9 +312,9 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			})
 		})
 
-		Context("when retrieving all the histories( start = 0, end = -1, order = 0) ", func() {
+		Context("when retrieving all the histories( start = 0, end = -1, orderType = DESC) ", func() {
 			BeforeEach(func() {
-				order = 0
+				orderType = db.DESC
 			})
 			It("returns all the histories of the app ordered by timestamp desc", func() {
 				Expect(err).NotTo(HaveOccurred())
@@ -368,7 +369,7 @@ var _ = Describe("ScalingEngineSqldb", func() {
 			BeforeEach(func() {
 				start = 333333
 				end = 555566
-				order = 0
+				orderType = db.DESC
 
 			})
 

--- a/src/autoscaler/scalingengine/fakes/fake_scalingengine_db.go
+++ b/src/autoscaler/scalingengine/fakes/fake_scalingengine_db.go
@@ -16,12 +16,13 @@ type FakeScalingEngineDB struct {
 	saveScalingHistoryReturns struct {
 		result1 error
 	}
-	RetrieveScalingHistoriesStub        func(appId string, start int64, end int64) ([]*models.AppScalingHistory, error)
+	RetrieveScalingHistoriesStub        func(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error)
 	retrieveScalingHistoriesMutex       sync.RWMutex
 	retrieveScalingHistoriesArgsForCall []struct {
 		appId string
 		start int64
 		end   int64
+		order int64
 	}
 	retrieveScalingHistoriesReturns struct {
 		result1 []*models.AppScalingHistory
@@ -105,9 +106,8 @@ func (fake *FakeScalingEngineDB) SaveScalingHistory(history *models.AppScalingHi
 	fake.saveScalingHistoryMutex.Unlock()
 	if fake.SaveScalingHistoryStub != nil {
 		return fake.SaveScalingHistoryStub(history)
-	} else {
-		return fake.saveScalingHistoryReturns.result1
 	}
+	return fake.saveScalingHistoryReturns.result1
 }
 
 func (fake *FakeScalingEngineDB) SaveScalingHistoryCallCount() int {
@@ -129,20 +129,20 @@ func (fake *FakeScalingEngineDB) SaveScalingHistoryReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeScalingEngineDB) RetrieveScalingHistories(appId string, start int64, end int64) ([]*models.AppScalingHistory, error) {
+func (fake *FakeScalingEngineDB) RetrieveScalingHistories(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error) {
 	fake.retrieveScalingHistoriesMutex.Lock()
 	fake.retrieveScalingHistoriesArgsForCall = append(fake.retrieveScalingHistoriesArgsForCall, struct {
 		appId string
 		start int64
 		end   int64
-	}{appId, start, end})
-	fake.recordInvocation("RetrieveScalingHistories", []interface{}{appId, start, end})
+		order int64
+	}{appId, start, end, order})
+	fake.recordInvocation("RetrieveScalingHistories", []interface{}{appId, start, end, order})
 	fake.retrieveScalingHistoriesMutex.Unlock()
 	if fake.RetrieveScalingHistoriesStub != nil {
-		return fake.RetrieveScalingHistoriesStub(appId, start, end)
-	} else {
-		return fake.retrieveScalingHistoriesReturns.result1, fake.retrieveScalingHistoriesReturns.result2
+		return fake.RetrieveScalingHistoriesStub(appId, start, end, order)
 	}
+	return fake.retrieveScalingHistoriesReturns.result1, fake.retrieveScalingHistoriesReturns.result2
 }
 
 func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesCallCount() int {
@@ -151,10 +151,10 @@ func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesCallCount() int {
 	return len(fake.retrieveScalingHistoriesArgsForCall)
 }
 
-func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesArgsForCall(i int) (string, int64, int64) {
+func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesArgsForCall(i int) (string, int64, int64, int64) {
 	fake.retrieveScalingHistoriesMutex.RLock()
 	defer fake.retrieveScalingHistoriesMutex.RUnlock()
-	return fake.retrieveScalingHistoriesArgsForCall[i].appId, fake.retrieveScalingHistoriesArgsForCall[i].start, fake.retrieveScalingHistoriesArgsForCall[i].end
+	return fake.retrieveScalingHistoriesArgsForCall[i].appId, fake.retrieveScalingHistoriesArgsForCall[i].start, fake.retrieveScalingHistoriesArgsForCall[i].end, fake.retrieveScalingHistoriesArgsForCall[i].order
 }
 
 func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesReturns(result1 []*models.AppScalingHistory, result2 error) {
@@ -174,9 +174,8 @@ func (fake *FakeScalingEngineDB) PruneScalingHistories(before int64) error {
 	fake.pruneScalingHistoriesMutex.Unlock()
 	if fake.PruneScalingHistoriesStub != nil {
 		return fake.PruneScalingHistoriesStub(before)
-	} else {
-		return fake.pruneScalingHistoriesReturns.result1
 	}
+	return fake.pruneScalingHistoriesReturns.result1
 }
 
 func (fake *FakeScalingEngineDB) PruneScalingHistoriesCallCount() int {
@@ -208,9 +207,8 @@ func (fake *FakeScalingEngineDB) UpdateScalingCooldownExpireTime(appId string, e
 	fake.updateScalingCooldownExpireTimeMutex.Unlock()
 	if fake.UpdateScalingCooldownExpireTimeStub != nil {
 		return fake.UpdateScalingCooldownExpireTimeStub(appId, expireAt)
-	} else {
-		return fake.updateScalingCooldownExpireTimeReturns.result1
 	}
+	return fake.updateScalingCooldownExpireTimeReturns.result1
 }
 
 func (fake *FakeScalingEngineDB) UpdateScalingCooldownExpireTimeCallCount() int {
@@ -241,9 +239,8 @@ func (fake *FakeScalingEngineDB) CanScaleApp(appId string) (bool, error) {
 	fake.canScaleAppMutex.Unlock()
 	if fake.CanScaleAppStub != nil {
 		return fake.CanScaleAppStub(appId)
-	} else {
-		return fake.canScaleAppReturns.result1, fake.canScaleAppReturns.result2
 	}
+	return fake.canScaleAppReturns.result1, fake.canScaleAppReturns.result2
 }
 
 func (fake *FakeScalingEngineDB) CanScaleAppCallCount() int {
@@ -275,9 +272,8 @@ func (fake *FakeScalingEngineDB) GetActiveSchedule(appId string) (*models.Active
 	fake.getActiveScheduleMutex.Unlock()
 	if fake.GetActiveScheduleStub != nil {
 		return fake.GetActiveScheduleStub(appId)
-	} else {
-		return fake.getActiveScheduleReturns.result1, fake.getActiveScheduleReturns.result2
 	}
+	return fake.getActiveScheduleReturns.result1, fake.getActiveScheduleReturns.result2
 }
 
 func (fake *FakeScalingEngineDB) GetActiveScheduleCallCount() int {
@@ -307,9 +303,8 @@ func (fake *FakeScalingEngineDB) GetActiveSchedules() (map[string]string, error)
 	fake.getActiveSchedulesMutex.Unlock()
 	if fake.GetActiveSchedulesStub != nil {
 		return fake.GetActiveSchedulesStub()
-	} else {
-		return fake.getActiveSchedulesReturns.result1, fake.getActiveSchedulesReturns.result2
 	}
+	return fake.getActiveSchedulesReturns.result1, fake.getActiveSchedulesReturns.result2
 }
 
 func (fake *FakeScalingEngineDB) GetActiveSchedulesCallCount() int {
@@ -336,9 +331,8 @@ func (fake *FakeScalingEngineDB) SetActiveSchedule(appId string, schedule *model
 	fake.setActiveScheduleMutex.Unlock()
 	if fake.SetActiveScheduleStub != nil {
 		return fake.SetActiveScheduleStub(appId, schedule)
-	} else {
-		return fake.setActiveScheduleReturns.result1
 	}
+	return fake.setActiveScheduleReturns.result1
 }
 
 func (fake *FakeScalingEngineDB) SetActiveScheduleCallCount() int {
@@ -369,9 +363,8 @@ func (fake *FakeScalingEngineDB) RemoveActiveSchedule(appId string) error {
 	fake.removeActiveScheduleMutex.Unlock()
 	if fake.RemoveActiveScheduleStub != nil {
 		return fake.RemoveActiveScheduleStub(appId)
-	} else {
-		return fake.removeActiveScheduleReturns.result1
 	}
+	return fake.removeActiveScheduleReturns.result1
 }
 
 func (fake *FakeScalingEngineDB) RemoveActiveScheduleCallCount() int {
@@ -400,9 +393,8 @@ func (fake *FakeScalingEngineDB) Close() error {
 	fake.closeMutex.Unlock()
 	if fake.CloseStub != nil {
 		return fake.CloseStub()
-	} else {
-		return fake.closeReturns.result1
 	}
+	return fake.closeReturns.result1
 }
 
 func (fake *FakeScalingEngineDB) CloseCallCount() int {

--- a/src/autoscaler/scalingengine/fakes/fake_scalingengine_db.go
+++ b/src/autoscaler/scalingengine/fakes/fake_scalingengine_db.go
@@ -16,13 +16,13 @@ type FakeScalingEngineDB struct {
 	saveScalingHistoryReturns struct {
 		result1 error
 	}
-	RetrieveScalingHistoriesStub        func(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error)
+	RetrieveScalingHistoriesStub        func(appId string, start int64, end int64, orderType db.OrderType) ([]*models.AppScalingHistory, error)
 	retrieveScalingHistoriesMutex       sync.RWMutex
 	retrieveScalingHistoriesArgsForCall []struct {
-		appId string
-		start int64
-		end   int64
-		order int64
+		appId     string
+		start     int64
+		end       int64
+		orderType db.OrderType
 	}
 	retrieveScalingHistoriesReturns struct {
 		result1 []*models.AppScalingHistory
@@ -129,18 +129,18 @@ func (fake *FakeScalingEngineDB) SaveScalingHistoryReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeScalingEngineDB) RetrieveScalingHistories(appId string, start int64, end int64, order int64) ([]*models.AppScalingHistory, error) {
+func (fake *FakeScalingEngineDB) RetrieveScalingHistories(appId string, start int64, end int64, orderType db.OrderType) ([]*models.AppScalingHistory, error) {
 	fake.retrieveScalingHistoriesMutex.Lock()
 	fake.retrieveScalingHistoriesArgsForCall = append(fake.retrieveScalingHistoriesArgsForCall, struct {
-		appId string
-		start int64
-		end   int64
-		order int64
-	}{appId, start, end, order})
-	fake.recordInvocation("RetrieveScalingHistories", []interface{}{appId, start, end, order})
+		appId     string
+		start     int64
+		end       int64
+		orderType db.OrderType
+	}{appId, start, end, orderType})
+	fake.recordInvocation("RetrieveScalingHistories", []interface{}{appId, start, end, orderType})
 	fake.retrieveScalingHistoriesMutex.Unlock()
 	if fake.RetrieveScalingHistoriesStub != nil {
-		return fake.RetrieveScalingHistoriesStub(appId, start, end, order)
+		return fake.RetrieveScalingHistoriesStub(appId, start, end, orderType)
 	}
 	return fake.retrieveScalingHistoriesReturns.result1, fake.retrieveScalingHistoriesReturns.result2
 }
@@ -151,10 +151,10 @@ func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesCallCount() int {
 	return len(fake.retrieveScalingHistoriesArgsForCall)
 }
 
-func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesArgsForCall(i int) (string, int64, int64, int64) {
+func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesArgsForCall(i int) (string, int64, int64, db.OrderType) {
 	fake.retrieveScalingHistoriesMutex.RLock()
 	defer fake.retrieveScalingHistoriesMutex.RUnlock()
-	return fake.retrieveScalingHistoriesArgsForCall[i].appId, fake.retrieveScalingHistoriesArgsForCall[i].start, fake.retrieveScalingHistoriesArgsForCall[i].end, fake.retrieveScalingHistoriesArgsForCall[i].order
+	return fake.retrieveScalingHistoriesArgsForCall[i].appId, fake.retrieveScalingHistoriesArgsForCall[i].start, fake.retrieveScalingHistoriesArgsForCall[i].end, fake.retrieveScalingHistoriesArgsForCall[i].orderType
 }
 
 func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesReturns(result1 []*models.AppScalingHistory, result2 error) {

--- a/src/autoscaler/scalingengine/server/scaling_handler.go
+++ b/src/autoscaler/scalingengine/server/scaling_handler.go
@@ -110,9 +110,9 @@ func (h *ScalingHandler) GetScalingHistories(w http.ResponseWriter, r *http.Requ
 
 	if len(orderParam) == 1 {
 		orderStr := strings.ToUpper(orderParam[0])
-		if orderStr == "DESC" {
+		if orderStr == db.DESCSTR {
 			order = db.DESC
-		} else if orderStr == "ASC" {
+		} else if orderStr == db.ASCSTR {
 			order = db.ASC
 		} else {
 			logger.Error("failed-to-get-order", err, lager.Data{"order": orderParam})

--- a/src/autoscaler/scalingengine/server/scaling_handler_test.go
+++ b/src/autoscaler/scalingengine/server/scaling_handler_test.go
@@ -310,7 +310,7 @@ var _ = Describe("ScalingHandler", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("queries scaling histories from database with order 0(desc) ", func() {
+				It("queries scaling histories from database with order desc", func() {
 					_, _, _, order := scalingEngineDB.RetrieveScalingHistoriesArgsForCall(0)
 					Expect(order).To(Equal(db.DESC))
 				})


### PR DESCRIPTION
…er type(asc or desc) for timestamp

[#146137973]