### PR TITLE
Modify return value for credentials of service instances

### DIFF
--- a/servicebroker/lib/routes/binding.js
+++ b/servicebroker/lib/routes/binding.js
@@ -73,7 +73,7 @@ module.exports = function(app, settings, catalog) {
                 switch(statusCode){
                   case 200:
                   case 201:
-                    commitTransaction(t, res, statusCode, {});
+                    commitTransaction(t, res, statusCode, {credentials: {}});
                     return;
                   case 400:
                     rollbackTransaction(t, res, statusCode, {error: response.body.error});


### PR DESCRIPTION
I would like to share my results.

## Issue
Related with
- https://github.com/cloudfoundry-incubator/app-autoscaler/issues/253
- https://github.com/cloudfoundry-incubator/app-autoscaler-release/issues/54

## Problem
CloudFoundryServiceInfoCreator class in Spring Framework does not handle null.

## Approach
Because the Spring framework does not handle nulls, I modified the following:

_app-autoscaler/servicebroker/lib/routes/binding.js_
```
...
switch(statusCode){
  case 200:
  case 201:
    commitTransaction(t, res, statusCode, {credentials: {}});
    return;
...
```

I tested it and it works fine.
```
$ cf env spring-music
Getting env variables for app spring-music in org cloudlab / space dev as admin...
OK

System-Provided:
{
 "VCAP_SERVICES": {
  "autoscaler": [
   {
    "credentials": {},
    "label": "autoscaler",
    "name": "autoscaler1",
    "plan": "autoscaler-free-plan",
    "provider": null,
    "syslog_drain_url": null,
    "tags": [],
    "volume_mounts": []
   }
  ]
 }
}
```

```
$ cf app spring-music
Showing health and status for app spring-music in org cloudlab / space dev as admin...
OK

requested state: started
instances: 4/4
usage: 512M x 4 instances
urls: spring-music.app.domain
last uploaded: Thu Jul 6 09:02:18 UTC 2017
stack: cflinuxfs2
buildpack: java_buildpack

     state     since                    cpu    memory           disk           details
#0   running   2017-07-07 11:03:44 AM   0.3%   474.5M of 512M   156.6M of 1G
#1   running   2017-07-07 11:14:30 AM   0.2%   449.4M of 512M   156.6M of 1G
#2   running   2017-07-07 11:19:50 AM   0.1%   381.5M of 512M   156.6M of 1G
#3   running   2017-07-07 11:25:10 AM   0.3%   395.1M of 512M   156.6M of 1G
```
