### PR TITLE
Enable database lock for singleton metricscollector without using consul based lock

### DIFF
--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"autoscaler/models"
+	"time"
 )
 
 const PostgresDriverName = "postgres"
@@ -53,5 +54,15 @@ type ScalingEngineDB interface {
 
 type SchedulerDB interface {
 	GetActiveSchedules() (map[string]*models.ActiveSchedule, error)
+	Close() error
+}
+
+type LockDB interface {
+	GetDatabaseTimestamp() (time.Time, error)
+	Lock(lock *models.Lock) (bool, error)
+	Fetch() (*models.Lock, error)
+	Acquire(lock *models.Lock) error
+	Release(owner string) error
+	Renew(owner string) error
 	Close() error
 }

--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"autoscaler/models"
-	"time"
 )
 
 const PostgresDriverName = "postgres"
@@ -58,11 +57,7 @@ type SchedulerDB interface {
 }
 
 type LockDB interface {
-	GetDatabaseTimestamp() (time.Time, error)
 	Lock(lock *models.Lock) (bool, error)
-	Fetch() (*models.Lock, error)
-	Acquire(lock *models.Lock) error
 	Release(owner string) error
-	Renew(owner string) error
 	Close() error
 }

--- a/src/autoscaler/db/sqldb/lock_sqldb.go
+++ b/src/autoscaler/db/sqldb/lock_sqldb.go
@@ -1,0 +1,241 @@
+package sqldb
+
+import (
+	"database/sql"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	_ "github.com/lib/pq"
+
+	"autoscaler/db"
+	"autoscaler/models"
+)
+
+type LockSQLDB struct {
+	url    string
+	logger lager.Logger
+	sqldb  *sql.DB
+}
+
+func NewLockSQLDB(url string, logger lager.Logger) (*LockSQLDB, error) {
+	sqldb, err := sql.Open(db.PostgresDriverName, url)
+	if err != nil {
+		logger.Error("open-lock-db", err, lager.Data{"url": url})
+		return nil, err
+	}
+
+	err = sqldb.Ping()
+	if err != nil {
+		sqldb.Close()
+		logger.Error("ping-lock-db", err, lager.Data{"url": url})
+		return nil, err
+	}
+
+	return &LockSQLDB{
+		url:    url,
+		logger: logger,
+		sqldb:  sqldb,
+	}, nil
+}
+
+func (ldb *LockSQLDB) Close() error {
+	err := ldb.sqldb.Close()
+	if err != nil {
+		ldb.logger.Error("close-lock-db", err, lager.Data{"url": ldb.url})
+		return err
+	}
+	return nil
+}
+
+func (ldb *LockSQLDB) Fetch() (lock *models.Lock, err error) {
+	ldb.logger.Info("fetching locks ")
+	var (
+		owner     string
+		timestamp time.Time
+		ttl       time.Duration
+	)
+	tx, err := ldb.sqldb.Begin()
+	if err != nil {
+		ldb.logger.Error("error-fetching-lock-transaction", err)
+		return nil, err
+	}
+	query := "SELECT * FROM locks"
+	err = tx.QueryRow(query).Scan(&owner, &timestamp, &ttl)
+	if err != nil {
+		return &models.Lock{}, err
+	}
+	err = tx.Commit()
+	if err != nil {
+		ldb.logger.Error("failed-to-commit-fetching-lock-transaction", err)
+		return &models.Lock{}, err
+	}
+	fetchedLock := &models.Lock{Owner: owner, LastModifiedTimestamp: timestamp, Ttl: ttl}
+	return fetchedLock, nil
+}
+
+func (ldb *LockSQLDB) Acquire(lockDetails *models.Lock) error {
+	ldb.logger.Info("acquiring-the-lock", lager.Data{"Owner": lockDetails.Owner, "LastModifiedTimestamp": lockDetails.LastModifiedTimestamp, "Ttl": lockDetails.Ttl})
+	tx, err := ldb.sqldb.Begin()
+	if err != nil {
+		ldb.logger.Error("error-starting-acquire-lock-transaction", err)
+		return err
+	}
+	defer func() {
+		if err != nil {
+			ldb.logger.Error("rolling-back-acquire-lock-transaction!", err)
+			err = tx.Rollback()
+			if err != nil {
+				ldb.logger.Error("failed-to-rollback-acquire-lock-transaction", err)
+			}
+			return
+		}
+		err = tx.Commit()
+		if err != nil {
+			ldb.logger.Error("failed-to-commit-acquire-lock-transaction", err)
+		}
+	}()
+	if _, err = tx.Exec("SELECT * FROM locks FOR UPDATE NOWAIT"); err != nil {
+		ldb.logger.Error("failed-to-select-for-update", err)
+		return err
+	}
+	currentTimestamp, err := ldb.GetDatabaseTimestamp()
+	if err != nil {
+		ldb.logger.Error("error-getting-timestamp-while-acquiring-lock", err)
+		return err
+	}
+	query := "INSERT INTO locks (owner,lock_timestamp,ttl) VALUES ($1,$2,$3)"
+	if _, err = tx.Exec(query, lockDetails.Owner, currentTimestamp, int64(lockDetails.Ttl/time.Second)); err != nil {
+		ldb.logger.Error("failed-to-insert-lock-details-during-acquire-lock", err)
+		return err
+	}
+	return err
+}
+
+func (ldb *LockSQLDB) Renew(owner string) error {
+	ldb.logger.Debug("renewing-lock", lager.Data{"Owner": owner})
+	tx, err := ldb.sqldb.Begin()
+	if err != nil {
+		ldb.logger.Error("error-starting-renew-lock-transaction", err)
+		return err
+	}
+	defer func() {
+		if err != nil {
+			ldb.logger.Error("rolling-back-renew-lock-transaction", err)
+			err = tx.Rollback()
+			if err != nil {
+				ldb.logger.Error("failed-to-rollback-renew-lock-transaction", err)
+			}
+			return
+		}
+		err = tx.Commit()
+		if err != nil {
+			ldb.logger.Error("failed-to-commit-renew-lock-transaction", err)
+		}
+	}()
+	query := "SELECT * FROM locks where owner=$1 FOR UPDATE NOWAIT"
+	if _, err = tx.Exec(query, owner); err != nil {
+		ldb.logger.Error("failed-to-select-for-update", err)
+		return err
+	}
+	currentTimestamp, err := ldb.GetDatabaseTimestamp()
+	if err != nil {
+		ldb.logger.Error("error-getting-timestamp-while-renewing-lock", err)
+		return err
+	}
+	updatequery := "UPDATE locks SET lock_timestamp=$1 where owner=$2"
+	if _, err = tx.Exec(updatequery, currentTimestamp, owner); err != nil {
+		ldb.logger.Error("failed-to-update-lock-details-during-lock-renewal", err)
+		return err
+	}
+	return err
+}
+
+func (ldb *LockSQLDB) Release(owner string) error {
+	ldb.logger.Debug("releasing-lock", lager.Data{"Owner": owner})
+	tx, err := ldb.sqldb.Begin()
+	if err != nil {
+		ldb.logger.Error("error-starting-release-lock-transaction", err)
+		return err
+	}
+	defer func() {
+		if err != nil {
+			ldb.logger.Error("rolling-back-release-lock-transaction!", err)
+			err = tx.Rollback()
+			if err != nil {
+				ldb.logger.Error("failed-to-rollback-release-lock-transaction", err)
+			}
+			return
+		}
+		err = tx.Commit()
+		if err != nil {
+			ldb.logger.Error("failed-to-commit-release-lock-transaction", err)
+		}
+	}()
+	if _, err := tx.Exec("SELECT * FROM locks FOR UPDATE NOWAIT"); err != nil {
+		ldb.logger.Error("failed-to-select-for-update", err)
+		return err
+	}
+	query := "DELETE FROM locks WHERE owner = $1"
+	if _, err := tx.Exec(query, owner); err != nil {
+		ldb.logger.Error("failed-to-delete-lock-details-during-release-lock", err)
+		return err
+	}
+	return nil
+}
+
+func (ldb *LockSQLDB) Lock(lock *models.Lock) (bool, error) {
+	fetchedLock, err := ldb.Fetch()
+	if err != nil && err == sql.ErrNoRows {
+		ldb.logger.Info("no-one-holds-the-lock")
+		err = ldb.Acquire(lock)
+		if err != nil {
+			ldb.logger.Error("failed-to-acquire-the-lock", err)
+			return false, err
+		}
+	} else if err != nil && err != sql.ErrNoRows {
+		ldb.logger.Error("failed-to-fetch-lock", err)
+		return false, err
+	} else {
+		if fetchedLock.Owner == lock.Owner {
+			err = ldb.Renew(lock.Owner)
+			if err != nil {
+				ldb.logger.Error("failed-to-renew-lock", err)
+				return false, err
+			}
+		} else {
+			ldb.logger.Debug("someone-else-owns-lock", lager.Data{"Owner": fetchedLock.Owner})
+			lastUpdatedTimestamp := fetchedLock.LastModifiedTimestamp
+			currentTimestamp, err := ldb.GetDatabaseTimestamp()
+			if err != nil {
+				ldb.logger.Error("error-getting-timestamp-while-getting-lock", err)
+				return false, err
+			}
+			if lastUpdatedTimestamp.Add(time.Second * time.Duration(fetchedLock.Ttl)).Before(currentTimestamp) {
+				ldb.logger.Info("lock-not-renewed-by-owner-forcefully-acquiring-the-lock", lager.Data{"Owner": fetchedLock.Owner})
+				err = ldb.Release(fetchedLock.Owner)
+				if err != nil {
+					ldb.logger.Error("failed-to-release-existing-lock", err)
+					return false, err
+				}
+				err = ldb.Acquire(lock)
+				if err != nil {
+					ldb.logger.Error("failed-to-acquire-lock", err)
+					return false, err
+				}
+			} else {
+				ldb.logger.Debug("lock-renewed-by-owner", lager.Data{"Owner": fetchedLock.Owner})
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func (ldb *LockSQLDB) GetDatabaseTimestamp() (time.Time, error) {
+	var currentTimestamp time.Time
+	err := ldb.sqldb.QueryRow("SELECT NOW() AT TIME ZONE 'utc'").Scan(&currentTimestamp)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return currentTimestamp, nil
+}

--- a/src/autoscaler/db/sqldb/lock_sqldb.go
+++ b/src/autoscaler/db/sqldb/lock_sqldb.go
@@ -228,7 +228,7 @@ func (ldb *LockSQLDB) transact(db *sql.DB, f func(tx *sql.Tx) error) error {
 		if attempts >= 2 || (err != driver.ErrBadConn) {
 			break
 		} else {
-			ldb.logger.Error("deadlock-transaction", err, lager.Data{"attempts": attempts})
+			ldb.logger.Info("wait-before-retry-for-transaction", lager.Data{"attempts": attempts})
 			time.Sleep(500 * time.Millisecond)
 		}
 	}

--- a/src/autoscaler/db/sqldb/lock_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/lock_sqldb_test.go
@@ -3,7 +3,6 @@ package sqldb_test
 import (
 	. "autoscaler/db/sqldb"
 	"autoscaler/models"
-	"database/sql"
 	"os"
 
 	"code.cloudfoundry.org/lager"
@@ -17,16 +16,13 @@ import (
 
 var _ = Describe("LockSqldb", func() {
 	var (
-		ldb                  *LockSQLDB
-		url                  string
-		logger               lager.Logger
-		err                  error
-		fetchedLocks         *models.Lock
-		isLockAcquired       bool
-		isSecondLockAcquired bool
-		secondErr            error
-		testTTL              time.Duration
-		timestamp            time.Time
+		ldb            *LockSQLDB
+		url            string
+		logger         lager.Logger
+		err            error
+		lock           *models.Lock
+		isLockAcquired bool
+		testTTL        time.Duration
 	)
 
 	BeforeEach(func() {
@@ -37,7 +33,7 @@ var _ = Describe("LockSqldb", func() {
 
 	Describe("NewLockSQLDB", func() {
 		JustBeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
+			ldb, err = NewLockSQLDB(url, "mc_lock", logger)
 		})
 
 		AfterEach(func() {
@@ -65,206 +61,144 @@ var _ = Describe("LockSqldb", func() {
 		})
 	})
 
-	Describe("Fetch Locks", func() {
-		BeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
-			Expect(err).NotTo(HaveOccurred())
-			cleanLockTable()
-		})
-
-		AfterEach(func() {
-			err = ldb.Close()
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		JustBeforeEach(func() {
-			fetchedLocks, err = ldb.Fetch()
-		})
-
-		Context("when lock table is empty", func() {
-			It("should not return any lock", func() {
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeIdenticalTo(sql.ErrNoRows))
-			})
-		})
-
-		Context("when lock table is not empty", func() {
-			BeforeEach(func() {
-				lock := models.Lock{Owner: "123456", Ttl: testTTL}
-				err = insertLockDetails(lock)
-			})
-
-			It("should return the lock", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fetchedLocks.Owner).To(Equal("123456"))
-				Expect(fetchedLocks.Ttl).To(Equal(testTTL))
-			})
-		})
-	})
-
-	Describe("Acquire Lock", func() {
-		BeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
-			Expect(err).NotTo(HaveOccurred())
-			cleanLockTable()
-		})
-
-		AfterEach(func() {
-			err = ldb.Close()
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		Context("when no lock owner exist", func() {
-			BeforeEach(func() {
-				newlock := &models.Lock{Owner: "123456", Ttl: testTTL}
-				err = ldb.Acquire(newlock)
-			})
-			It("should successfully acquire the lock", func() {
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
 	Describe("Lock", func() {
 		BeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
+			ldb, err = NewLockSQLDB(url, "mc_lock", logger)
 			Expect(err).NotTo(HaveOccurred())
-			cleanLockTable()
 		})
 
 		AfterEach(func() {
 			err = ldb.Close()
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		Context("when no instance owns the lock", func() {
-			BeforeEach(func() {
-				lock := &models.Lock{Owner: "123456", Ttl: testTTL}
-				isLockAcquired, err = ldb.Lock(lock)
-			})
-
-			It("competing instance should successfully acquire the lock", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(isLockAcquired).To(BeTrue())
-			})
-		})
-
-		Context("when lock owned by an instance", func() {
-			BeforeEach(func() {
-				lock := &models.Lock{Owner: "654321", Ttl: testTTL}
-				isLockAcquired, err = ldb.Lock(lock)
-				Expect(err).NotTo(HaveOccurred())
-				lock = &models.Lock{Owner: "654321", Ttl: testTTL}
-				isLockAcquired, err = ldb.Lock(lock)
-			})
-			It("same instance should successfully renew it's lock", func() {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(isLockAcquired).To(BeTrue())
-			})
-		})
-		Context("when lock recently renewed by owner instance", func() {
-			BeforeEach(func() {
-				lock := &models.Lock{Owner: "654321", Ttl: testTTL}
-				isLockAcquired, err = ldb.Lock(lock)
-				Expect(err).NotTo(HaveOccurred())
-				secondlock := &models.Lock{Owner: "123456", Ttl: testTTL}
-				isSecondLockAcquired, secondErr = ldb.Lock(secondlock)
-			})
-			It("competing instance should fail to acquire the lock", func() {
-				Expect(secondErr).NotTo(HaveOccurred())
-				Expect(isSecondLockAcquired).NotTo(BeTrue())
-			})
-		})
-
-		Context("Lock owned by some instance but expired", func() {
-			BeforeEach(func() {
-				lock := &models.Lock{Owner: "654321", Ttl: time.Duration(3) * time.Second}
-				isLockAcquired, err = ldb.Lock(lock)
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(4 * time.Second)
-				secondlock := &models.Lock{Owner: "123456", Ttl: testTTL}
-				isSecondLockAcquired, secondErr = ldb.Lock(secondlock)
-			})
-			It("competing instance should successfully acquire the lock", func() {
-				Expect(secondErr).NotTo(HaveOccurred())
-				Expect(isSecondLockAcquired).To(BeTrue())
-			})
-		})
-	})
-
-	Describe("Renew Lock", func() {
-		BeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
-			Expect(err).NotTo(HaveOccurred())
 			cleanLockTable()
 		})
 
-		AfterEach(func() {
-			err = ldb.Close()
-			Expect(err).NotTo(HaveOccurred())
+		Context("when the lock does not exist", func() {
+			Context("because the row does not exist", func() {
+				BeforeEach(func() {
+					lock = &models.Lock{Owner: "123456", Ttl: testTTL}
+				})
+
+				It("insert the lock for the owner", func() {
+					isLockAcquired, err = ldb.Lock(lock)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(isLockAcquired).To(BeTrue())
+					Expect(validateLockInDB("123456", lock)).To(Succeed())
+				})
+			})
 		})
 
-		Context("when lock owned by an instance", func() {
-			BeforeEach(func() {
-				lock := &models.Lock{Owner: "123456", Ttl: testTTL}
-				err = ldb.Acquire(lock)
-				Expect(err).NotTo(HaveOccurred())
-				err = ldb.Renew("123456")
+		Context("when the lock exist", func() {
+			Context("and the owner is same", func() {
+				BeforeEach(func() {
+					lock = &models.Lock{Owner: "213123313", Ttl: testTTL}
+					result, err := insertLockDetails(lock)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.RowsAffected()).To(BeEquivalentTo(1))
+					Expect(validateLockInDB("213123313", lock)).To(Succeed())
+				})
+				It("should successfully renew the lock", func() {
+					lock = &models.Lock{Owner: "213123313", Ttl: testTTL}
+					isLockAcquired, err = ldb.Lock(lock)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(isLockAcquired).To(BeTrue())
+				})
 			})
-			It("same instance should able to renew the lock successfully", func() {
+
+			Context("and the owner is different", func() {
+				Context("and lock recently renewed by owner", func() {
+					BeforeEach(func() {
+						lock = &models.Lock{Owner: "65432199", Ttl: testTTL}
+						isLockAcquired, err = ldb.Lock(lock)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(isLockAcquired).To(BeTrue())
+						Expect(validateLockInDB("65432199", lock)).To(Succeed())
+					})
+					It("competing instance should fail to get the lock", func() {
+						lock = &models.Lock{Owner: "1234567", Ttl: testTTL}
+						isLockAcquired, err = ldb.Lock(lock)
+						Expect(isLockAcquired).To(BeFalse())
+						Expect(validateLockInDB("1234567", lock)).NotTo(Succeed())
+					})
+				})
+
+				Context("and lock expired", func() {
+					It("competing instance should successfully acquire the lock", func() {
+						time.Sleep(testTTL + 5*time.Second) //waiting for the ttl to expire
+						lock = &models.Lock{Owner: "123456", Ttl: testTTL}
+						isLockAcquired, err = ldb.Lock(lock)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(isLockAcquired).To(BeTrue())
+						Expect(validateLockInDB("123456", lock)).To(Succeed())
+					})
+
+				})
+			})
+
+		})
+
+		Context("when the lock table disappears", func() {
+			BeforeEach(func() {
+				err = dropLockTable()
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				err = createLockTable()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fail to acquire lock", func() {
+				lock = &models.Lock{Owner: "123456", Ttl: testTTL}
+				isLockAcquired, err = ldb.Lock(lock)
+				Expect(err).To(HaveOccurred())
+				Expect(isLockAcquired).To(BeFalse())
 			})
 		})
 	})
 
 	Describe("Release Lock", func() {
 		BeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
+			ldb, err = NewLockSQLDB(url, "mc_lock", logger)
 			Expect(err).NotTo(HaveOccurred())
-			cleanLockTable()
+			lock = &models.Lock{Owner: "654321", Ttl: testTTL}
 		})
 
 		AfterEach(func() {
 			err = ldb.Close()
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		Context("when owner instance wants to release the lock", func() {
-			BeforeEach(func() {
-				lock := &models.Lock{Owner: "123456", Ttl: testTTL}
-				err = ldb.Acquire(lock)
-				Expect(err).NotTo(HaveOccurred())
-				err = ldb.Release("123456")
-			})
-			It("owner instance should able to release the lock successfully", func() {
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Describe("Get Database Timestamp", func() {
-		BeforeEach(func() {
-			ldb, err = NewLockSQLDB(url, logger)
-			Expect(err).NotTo(HaveOccurred())
 			cleanLockTable()
 		})
 
-		AfterEach(func() {
-			err = ldb.Close()
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		Context("when fetching current database timestamp", func() {
+		Context("when the lock exist", func() {
 			BeforeEach(func() {
-				timestamp, err = ldb.GetDatabaseTimestamp()
-			})
-
-			It("should not throw an error ", func() {
+				result, err := insertLockDetails(lock)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(timestamp).Should(BeAssignableToTypeOf(time.Time{}))
+				Expect(result.RowsAffected()).To(BeEquivalentTo(1))
+				Expect(validateLockInDB("654321", lock)).To(Succeed())
+			})
+			It("removes the lock from the locks table", func() {
+				err = ldb.Release(lock.Owner)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(validateLockNotInDB("654321")).To(Succeed())
 			})
 		})
 
-	})
+		Context("when the lock table disappears", func() {
+			BeforeEach(func() {
+				err = dropLockTable()
+				Expect(err).NotTo(HaveOccurred())
+			})
 
+			AfterEach(func() {
+				err = createLockTable()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fail to release lock", func() {
+				err = ldb.Release(lock.Owner)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })

--- a/src/autoscaler/db/sqldb/lock_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/lock_sqldb_test.go
@@ -1,0 +1,270 @@
+package sqldb_test
+
+import (
+	. "autoscaler/db/sqldb"
+	"autoscaler/models"
+	"database/sql"
+	"os"
+
+	"code.cloudfoundry.org/lager"
+
+	"time"
+
+	"github.com/lib/pq"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LockSqldb", func() {
+	var (
+		ldb                  *LockSQLDB
+		url                  string
+		logger               lager.Logger
+		err                  error
+		fetchedLocks         *models.Lock
+		isLockAcquired       bool
+		isSecondLockAcquired bool
+		secondErr            error
+		testTTL              time.Duration
+		timestamp            time.Time
+	)
+
+	BeforeEach(func() {
+		logger = lager.NewLogger("lock-sqldb-test")
+		url = os.Getenv("DBURL")
+		testTTL = time.Duration(15) * time.Second
+	})
+
+	Describe("NewLockSQLDB", func() {
+		JustBeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+		})
+
+		AfterEach(func() {
+			if ldb != nil {
+				err = ldb.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		Context("when lock db url is not correct", func() {
+			BeforeEach(func() {
+				url = "postgres://not-exist-user:not-exist-password@localhost/autoscaler?sslmode=disable"
+			})
+			It("should throw an error", func() {
+				Expect(err).To(BeAssignableToTypeOf(&pq.Error{}))
+			})
+
+		})
+
+		Context("when lock db url is correct", func() {
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ldb).NotTo(BeNil())
+			})
+		})
+	})
+
+	Describe("Fetch Locks", func() {
+		BeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanLockTable()
+		})
+
+		AfterEach(func() {
+			err = ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			fetchedLocks, err = ldb.Fetch()
+		})
+
+		Context("when lock table is empty", func() {
+			It("should not return any lock", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeIdenticalTo(sql.ErrNoRows))
+			})
+		})
+
+		Context("when lock table is not empty", func() {
+			BeforeEach(func() {
+				lock := models.Lock{Owner: "123456", Ttl: testTTL}
+				err = insertLockDetails(lock)
+			})
+
+			It("should return the lock", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fetchedLocks.Owner).To(Equal("123456"))
+				Expect(fetchedLocks.Ttl).To(Equal(testTTL))
+			})
+		})
+	})
+
+	Describe("Acquire Lock", func() {
+		BeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanLockTable()
+		})
+
+		AfterEach(func() {
+			err = ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when no lock owner exist", func() {
+			BeforeEach(func() {
+				newlock := &models.Lock{Owner: "123456", Ttl: testTTL}
+				err = ldb.Acquire(newlock)
+			})
+			It("should successfully acquire the lock", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Lock", func() {
+		BeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanLockTable()
+		})
+
+		AfterEach(func() {
+			err = ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when no instance owns the lock", func() {
+			BeforeEach(func() {
+				lock := &models.Lock{Owner: "123456", Ttl: testTTL}
+				isLockAcquired, err = ldb.Lock(lock)
+			})
+
+			It("competing instance should successfully acquire the lock", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isLockAcquired).To(BeTrue())
+			})
+		})
+
+		Context("when lock owned by an instance", func() {
+			BeforeEach(func() {
+				lock := &models.Lock{Owner: "654321", Ttl: testTTL}
+				isLockAcquired, err = ldb.Lock(lock)
+				Expect(err).NotTo(HaveOccurred())
+				lock = &models.Lock{Owner: "654321", Ttl: testTTL}
+				isLockAcquired, err = ldb.Lock(lock)
+			})
+			It("same instance should successfully renew it's lock", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isLockAcquired).To(BeTrue())
+			})
+		})
+		Context("when lock recently renewed by owner instance", func() {
+			BeforeEach(func() {
+				lock := &models.Lock{Owner: "654321", Ttl: testTTL}
+				isLockAcquired, err = ldb.Lock(lock)
+				Expect(err).NotTo(HaveOccurred())
+				secondlock := &models.Lock{Owner: "123456", Ttl: testTTL}
+				isSecondLockAcquired, secondErr = ldb.Lock(secondlock)
+			})
+			It("competing instance should fail to acquire the lock", func() {
+				Expect(secondErr).NotTo(HaveOccurred())
+				Expect(isSecondLockAcquired).NotTo(BeTrue())
+			})
+		})
+
+		Context("Lock owned by some instance but expired", func() {
+			BeforeEach(func() {
+				lock := &models.Lock{Owner: "654321", Ttl: time.Duration(3) * time.Second}
+				isLockAcquired, err = ldb.Lock(lock)
+				Expect(err).NotTo(HaveOccurred())
+				time.Sleep(4 * time.Second)
+				secondlock := &models.Lock{Owner: "123456", Ttl: testTTL}
+				isSecondLockAcquired, secondErr = ldb.Lock(secondlock)
+			})
+			It("competing instance should successfully acquire the lock", func() {
+				Expect(secondErr).NotTo(HaveOccurred())
+				Expect(isSecondLockAcquired).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Renew Lock", func() {
+		BeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanLockTable()
+		})
+
+		AfterEach(func() {
+			err = ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when lock owned by an instance", func() {
+			BeforeEach(func() {
+				lock := &models.Lock{Owner: "123456", Ttl: testTTL}
+				err = ldb.Acquire(lock)
+				Expect(err).NotTo(HaveOccurred())
+				err = ldb.Renew("123456")
+			})
+			It("same instance should able to renew the lock successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Release Lock", func() {
+		BeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanLockTable()
+		})
+
+		AfterEach(func() {
+			err = ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when owner instance wants to release the lock", func() {
+			BeforeEach(func() {
+				lock := &models.Lock{Owner: "123456", Ttl: testTTL}
+				err = ldb.Acquire(lock)
+				Expect(err).NotTo(HaveOccurred())
+				err = ldb.Release("123456")
+			})
+			It("owner instance should able to release the lock successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Get Database Timestamp", func() {
+		BeforeEach(func() {
+			ldb, err = NewLockSQLDB(url, logger)
+			Expect(err).NotTo(HaveOccurred())
+			cleanLockTable()
+		})
+
+		AfterEach(func() {
+			err = ldb.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when fetching current database timestamp", func() {
+			BeforeEach(func() {
+				timestamp, err = ldb.GetDatabaseTimestamp()
+			})
+
+			It("should not throw an error ", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(timestamp).Should(BeAssignableToTypeOf(time.Time{}))
+			})
+		})
+
+	})
+
+})

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -194,3 +194,14 @@ func insertSchedulerActiveSchedule(id int, appId string, startJobIdentifier int,
 	}
 	return e
 }
+
+func insertLockDetails(lock models.Lock) error {
+	query := "INSERT INTO locks (owner,lock_timestamp,ttl) VALUES ($1,$2,$3)"
+	_, err := dbHelper.Exec(query, lock.Owner, lock.LastModifiedTimestamp, lock.Ttl)
+	return err
+}
+
+func cleanLockTable() error {
+	_, e := dbHelper.Exec("DELETE FROM locks")
+	return e
+}

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -3,8 +3,11 @@ package sqldb_test
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"autoscaler/db"
 	"autoscaler/models"
@@ -195,13 +198,80 @@ func insertSchedulerActiveSchedule(id int, appId string, startJobIdentifier int,
 	return e
 }
 
-func insertLockDetails(lock models.Lock) error {
-	query := "INSERT INTO locks (owner,lock_timestamp,ttl) VALUES ($1,$2,$3)"
-	_, err := dbHelper.Exec(query, lock.Owner, lock.LastModifiedTimestamp, lock.Ttl)
-	return err
+func insertLockDetails(lock *models.Lock) (sql.Result, error) {
+	query := "INSERT INTO mc_lock (owner,lock_timestamp,ttl) VALUES ($1,$2,$3)"
+	result, err := dbHelper.Exec(query, lock.Owner, lock.LastModifiedTimestamp, int64(lock.Ttl/time.Second))
+	return result, err
 }
 
 func cleanLockTable() error {
-	_, e := dbHelper.Exec("DELETE FROM locks")
-	return e
+	_, err := dbHelper.Exec("DELETE FROM mc_lock")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func dropLockTable() error {
+	_, err := dbHelper.Exec("DROP TABLE mc_lock")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createLockTable() error {
+	_, err := dbHelper.Exec(`
+		CREATE TABLE IF NOT EXISTS mc_lock (
+			owner VARCHAR(255) PRIMARY KEY,
+			lock_timestamp TIMESTAMP  NOT NULL,
+			ttl BIGINT DEFAULT 0
+		);
+	`)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateLockInDB(ownerid string, expectedLock *models.Lock) error {
+	var (
+		timestamp time.Time
+		ttl       time.Duration
+		owner     string
+	)
+	query := "SELECT owner,lock_timestamp,ttl FROM mc_lock WHERE owner=$1"
+	row := dbHelper.QueryRow(query, ownerid)
+	err := row.Scan(&owner, &timestamp, &ttl)
+	if err != nil {
+		return err
+	}
+	errMsg := ""
+	if expectedLock.Owner != owner {
+		errMsg += fmt.Sprintf("mismatch owner (%d, %d),", expectedLock.Owner, owner)
+	}
+	if expectedLock.Ttl != time.Second*time.Duration(ttl) {
+		errMsg += fmt.Sprintf("mismatch ttl (%d, %d),", expectedLock.Ttl, time.Second*time.Duration(ttl))
+	}
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
+	return nil
+}
+
+func validateLockNotInDB(owner string) error {
+	var (
+		timestamp time.Time
+		ttl       time.Duration
+	)
+	query := "SELECT owner,lock_timestamp,ttl FROM mc_lock WHERE owner=$1"
+	row := dbHelper.QueryRow(query, owner)
+	err := row.Scan(&owner, &timestamp, &ttl)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return err
+	}
+	return fmt.Errorf("lock exists with owner (%s)", owner)
 }

--- a/src/autoscaler/metricscollector/cmd/metricscollector/main.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"autoscaler/cf"
@@ -14,12 +15,14 @@ import (
 	"autoscaler/metricscollector/collector"
 	"autoscaler/metricscollector/config"
 	"autoscaler/metricscollector/server"
+	"autoscaler/models"
 
 	"code.cloudfoundry.org/cfhttp"
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/consuladapter"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/locket"
+	cfenv "github.com/cloudfoundry-community/go-cfenv"
 	"github.com/cloudfoundry/noaa/consumer"
 	"github.com/hashicorp/consul/api"
 	"github.com/nu7hatch/gouuid"
@@ -127,6 +130,19 @@ func main() {
 		{"http_server", httpServer},
 	}
 
+	if conf.EnableDBLock {
+		logger.Info("database-lock-feature-enabled")
+		var lockDB db.LockDB
+		lockDB, err = sqldb.NewLockSQLDB(conf.DBLock.LockDBURL, logger.Session("lock-db"))
+		if err != nil {
+			logger.Error("failed-to-connect-lock-database", err, lager.Data{"url": conf.DBLock.LockDBURL})
+			os.Exit(1)
+		}
+		defer lockDB.Close()
+		dbLockMaintainer := initDBLockRunner(conf, logger, lockDB)
+		members = append(grouper.Members{{"db-lock-maintainer", dbLockMaintainer}}, members...)
+	}
+
 	if conf.Lock.ConsulClusterConfig != "" {
 		consulClient, err := consuladapter.NewClientFromUrl(conf.Lock.ConsulClusterConfig)
 		if err != nil {
@@ -134,16 +150,17 @@ func main() {
 		}
 
 		serviceClient := metricscollector.NewServiceClient(consulClient, mcClock)
-		lockMaintainer := serviceClient.NewMetricsCollectorLockRunner(
-			logger,
-			generateGUID(logger),
-			conf.Lock.LockRetryInterval,
-			conf.Lock.LockTTL,
-		)
-
+		if !conf.EnableDBLock {
+			lockMaintainer := serviceClient.NewMetricsCollectorLockRunner(
+				logger,
+				generateGUID(logger),
+				conf.Lock.LockRetryInterval,
+				conf.Lock.LockTTL,
+			)
+			members = append(grouper.Members{{"lock-maintainer", lockMaintainer}}, members...)
+		}
 		registrationRunner := initializeRegistrationRunner(logger, consulClient, conf.Server.Port, mcClock)
 
-		members = append(grouper.Members{{"lock-maintainer", lockMaintainer}}, members...)
 		members = append(members, grouper.Member{"registration", registrationRunner})
 	}
 
@@ -157,6 +174,65 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("exited")
+}
+
+func initDBLockRunner(conf *config.Config, logger lager.Logger, lockDB db.LockDB) ifrit.Runner {
+	dbLockMaintainer := ifrit.RunFunc(func(signals <-chan os.Signal, ready chan<- struct{}) error {
+		ttl := conf.DBLock.LockTTL
+		lockTicker := time.NewTicker(ttl)
+		readyFlag := true
+		owner := getOwner(logger, conf)
+		if owner == "" {
+			logger.Info("failed-to-get-owner-details")
+			os.Exit(1)
+		}
+		lock := &models.Lock{Owner: owner, Ttl: ttl}
+		isLockAcquired, lockErr := lockDB.Lock(lock)
+		if lockErr != nil {
+			logger.Error("failed-to-acquire-lock-in-first-attempt", lockErr)
+		}
+		if isLockAcquired {
+			logger.Info("lock-acquired-in-first-attempt", lager.Data{"owner": owner, "isLockAcquired": isLockAcquired})
+			close(ready)
+			readyFlag = false
+		}
+		for {
+			select {
+			case <-signals:
+				logger.Info("received-interrupt-signal", lager.Data{"owner": owner})
+				lockTicker.Stop()
+				releaseErr := lockDB.Release(owner)
+				if releaseErr != nil {
+					logger.Error("failed-to-release-lock ", releaseErr)
+				} else {
+					logger.Info("successfully-released-lock", lager.Data{"owner": owner})
+				}
+				readyFlag = true
+				return nil
+
+			case <-lockTicker.C:
+				logger.Info("retry-acquiring-lock", lager.Data{"owner": owner})
+				lock := &models.Lock{Owner: owner, Ttl: ttl}
+				isLockAcquired, lockErr := lockDB.Lock(lock)
+				if lockErr != nil {
+					logger.Error("failed-to-acquire-lock", lockErr)
+					releaseErr := lockDB.Release(owner)
+					if releaseErr != nil {
+						logger.Error("failed-to-release-lock ", releaseErr)
+					} else {
+						logger.Info("successfully-released-lock", lager.Data{"owner": owner})
+					}
+					os.Exit(1)
+				}
+				if isLockAcquired && readyFlag {
+					close(ready)
+					readyFlag = false
+					logger.Info("successfully-acquired-lock", lager.Data{"owner": owner})
+				}
+			}
+		}
+	})
+	return dbLockMaintainer
 }
 
 func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
@@ -207,4 +283,17 @@ func generateGUID(logger lager.Logger) string {
 		logger.Fatal("Couldn't generate uuid", err)
 	}
 	return uuid.String()
+}
+
+func getOwner(logger lager.Logger, conf *config.Config) string {
+	var owner string
+	if strings.TrimSpace(os.Getenv("VCAP_APPLICATION")) != "" {
+		appEnv, _ := cfenv.Current()
+		owner = appEnv.ID
+		logger.Info("ownership found in VCAP_APPLICATION", lager.Data{"owner": owner})
+	} else if conf.DBLock.Owner != "" {
+		owner = conf.DBLock.Owner
+		logger.Info("ownership found in config file", lager.Data{"owner": owner})
+	}
+	return owner
 }

--- a/src/autoscaler/metricscollector/cmd/metricscollector/main.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/main.go
@@ -144,7 +144,7 @@ func main() {
 		}
 		defer lockDB.Close()
 		mcdl := sync.NewDatabaseLock(logger)
-		dbLockMaintainer := mcdl.InitDBLockRunner(conf.DBLock.LockTTL, guid, lockDB)
+		dbLockMaintainer := mcdl.InitDBLockRunner(conf.DBLock.LockRetryInterval, conf.DBLock.LockTTL, guid, lockDB)
 		members = append(grouper.Members{{"db-lock-maintainer", dbLockMaintainer}}, members...)
 	}
 

--- a/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
@@ -165,7 +165,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	cfg.DBLock.LockDBURL = os.Getenv("DBURL")
 	cfg.DBLock.LockTTL = 5 * time.Second
-	cfg.DBLock.Owner = "12345"
 	cfg.EnableDBLock = false
 
 	configFile = writeConfig(&cfg)
@@ -287,6 +286,6 @@ func (mc *MetricsCollectorRunner) ClearLockDatabase() {
 	lockDB, err := sql.Open(db.PostgresDriverName, os.Getenv("DBURL"))
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = lockDB.Exec("DELETE FROM locks")
+	_, err = lockDB.Exec("DELETE FROM mc_lock")
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
@@ -163,6 +163,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	cfg.Lock.LockRetryInterval = locket.RetryInterval
 	cfg.Lock.LockTTL = locket.DefaultSessionTTL
 
+	cfg.DBLock.LockDBURL = os.Getenv("DBURL")
+	cfg.DBLock.LockTTL = 5 * time.Second
+	cfg.DBLock.Owner = "12345"
+	cfg.EnableDBLock = false
+
 	configFile = writeConfig(&cfg)
 
 	tlsConfig, err := cfhttp.NewTLSConfig(
@@ -276,4 +281,12 @@ func marshalMessage(message *events.Envelope) []byte {
 	}
 
 	return data
+}
+
+func (mc *MetricsCollectorRunner) ClearLockDatabase() {
+	lockDB, err := sql.Open(db.PostgresDriverName, os.Getenv("DBURL"))
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = lockDB.Exec("DELETE FROM locks")
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_suite_test.go
@@ -164,7 +164,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	cfg.Lock.LockTTL = locket.DefaultSessionTTL
 
 	cfg.DBLock.LockDBURL = os.Getenv("DBURL")
-	cfg.DBLock.LockTTL = 5 * time.Second
+	cfg.DBLock.LockTTL = 15 * time.Second
+	cfg.DBLock.LockRetryInterval = 5 * time.Second
 	cfg.EnableDBLock = false
 
 	configFile = writeConfig(&cfg)

--- a/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_test.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/metricscollector_test.go
@@ -372,7 +372,6 @@ var _ = Describe("MetricsCollector", func() {
 
 				secondRunner = NewMetricsCollectorRunner()
 				consulConfig.Server.Port = 8000
-				consulConfig.DBLock.Owner = "second-owner"
 				secondRunner.startCheck = ""
 				secondRunner.configPath = writeConfig(&consulConfig).Name()
 				secondRunner.Start()
@@ -395,7 +394,6 @@ var _ = Describe("MetricsCollector", func() {
 				Eventually(runner.Session.Buffer, 10*time.Second).Should(gbytes.Say("metricscollector.started"))
 				secondRunner = NewMetricsCollectorRunner()
 				consulConfig.Server.Port = 8000
-				consulConfig.DBLock.Owner = "second-owner"
 				secondRunner.configPath = writeConfig(&consulConfig).Name()
 				secondRunner.startCheck = ""
 				secondRunner.Start()

--- a/src/autoscaler/metricscollector/config/config.go
+++ b/src/autoscaler/metricscollector/config/config.go
@@ -71,7 +71,6 @@ type LockConfig struct {
 }
 
 type DBLockConfig struct {
-	Owner     string        `yaml:"owner"`
 	LockTTL   time.Duration `yaml:"ttl"`
 	LockDBURL string        `yaml:"url"`
 }
@@ -151,10 +150,6 @@ func (c *Config) Validate() error {
 
 	if c.EnableDBLock && c.DBLock.LockTTL == time.Duration(0) {
 		return fmt.Errorf("Configuration error: Lock TTL is empty ")
-	}
-
-	if c.EnableDBLock && c.DBLock.Owner == "" {
-		return fmt.Errorf("Configuration error: Lock Owner is empty ")
 	}
 
 	return nil

--- a/src/autoscaler/metricscollector/config/config_test.go
+++ b/src/autoscaler/metricscollector/config/config_test.go
@@ -101,7 +101,6 @@ lock:
   consul_cluster_config: http://127.0.0.1:8500
 enable_db_lock: true
 db_lock:
-  owner: 123445687
   ttl: 30s
   url: postgres://pqgotest:password@localhost/pqgotest
 `)
@@ -138,7 +137,6 @@ db_lock:
 
 				Expect(conf.DBLock.LockDBURL).To(Equal("postgres://pqgotest:password@localhost/pqgotest"))
 				Expect(conf.DBLock.LockTTL).To(Equal(30 * time.Second))
-				Expect(conf.DBLock.Owner).To(Equal("123445687"))
 				Expect(conf.EnableDBLock).To(Equal(true))
 			})
 		})
@@ -185,7 +183,6 @@ db:
 			conf.Collector.CollectMethod = CollectMethodPolling
 			conf.DBLock.LockDBURL = "postgres://pqgotest:password@exampl.com/pqgotest"
 			conf.DBLock.LockTTL = time.Duration(30 * time.Second)
-			conf.DBLock.Owner = "123456"
 			conf.EnableDBLock = true
 		})
 
@@ -280,17 +277,5 @@ db:
 				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock TTL is empty")))
 			})
 		})
-
-		Context("when lock owner is not set but dblock enabled", func() {
-			BeforeEach(func() {
-				conf.EnableDBLock = true
-				conf.DBLock.Owner = ""
-			})
-
-			It("should error", func() {
-				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock Owner is empty")))
-			})
-		})
-
 	})
 })

--- a/src/autoscaler/metricscollector/config/config_test.go
+++ b/src/autoscaler/metricscollector/config/config_test.go
@@ -103,6 +103,7 @@ enable_db_lock: true
 db_lock:
   ttl: 30s
   url: postgres://pqgotest:password@localhost/pqgotest
+  retry_interval: 5s
 `)
 			})
 
@@ -138,6 +139,7 @@ db_lock:
 				Expect(conf.DBLock.LockDBURL).To(Equal("postgres://pqgotest:password@localhost/pqgotest"))
 				Expect(conf.DBLock.LockTTL).To(Equal(30 * time.Second))
 				Expect(conf.EnableDBLock).To(Equal(true))
+				Expect(conf.DBLock.LockRetryInterval).To(Equal(5 * time.Second))
 			})
 		})
 
@@ -165,6 +167,8 @@ db:
 				Expect(conf.Lock.LockRetryInterval).To(Equal(DefaultRetryInterval))
 				Expect(conf.Lock.LockTTL).To(Equal(DefaultLockTTL))
 				Expect(conf.EnableDBLock).To(Equal(false))
+				Expect(conf.DBLock.LockTTL).To(Equal(DefaultDBLockTTL))
+				Expect(conf.DBLock.LockRetryInterval).To(Equal(DefaultDBLockRetryInterval))
 			})
 		})
 	})
@@ -182,7 +186,6 @@ db:
 			conf.Collector.RefreshInterval = time.Duration(60 * time.Second)
 			conf.Collector.CollectMethod = CollectMethodPolling
 			conf.DBLock.LockDBURL = "postgres://pqgotest:password@exampl.com/pqgotest"
-			conf.DBLock.LockTTL = time.Duration(30 * time.Second)
 			conf.EnableDBLock = true
 		})
 
@@ -264,17 +267,6 @@ db:
 
 			It("should error", func() {
 				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock DB URL is empty")))
-			})
-		})
-
-		Context("when lock ttl is not set but dblock enabled ", func() {
-			BeforeEach(func() {
-				conf.EnableDBLock = true
-				conf.DBLock.LockTTL = time.Duration(0)
-			})
-
-			It("should error", func() {
-				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock TTL is empty")))
 			})
 		})
 	})

--- a/src/autoscaler/metricscollector/config/config_test.go
+++ b/src/autoscaler/metricscollector/config/config_test.go
@@ -99,6 +99,11 @@ lock:
   lock_ttl: 15s
   lock_retry_interval: 10s
   consul_cluster_config: http://127.0.0.1:8500
+enable_db_lock: true
+db_lock:
+  owner: 123445687
+  ttl: 30s
+  url: postgres://pqgotest:password@localhost/pqgotest
 `)
 			})
 
@@ -130,6 +135,11 @@ lock:
 				Expect(conf.Lock.ConsulClusterConfig).To(Equal("http://127.0.0.1:8500"))
 				Expect(conf.Lock.LockRetryInterval).To(Equal(10 * time.Second))
 				Expect(conf.Lock.LockTTL).To(Equal(15 * time.Second))
+
+				Expect(conf.DBLock.LockDBURL).To(Equal("postgres://pqgotest:password@localhost/pqgotest"))
+				Expect(conf.DBLock.LockTTL).To(Equal(30 * time.Second))
+				Expect(conf.DBLock.Owner).To(Equal("123445687"))
+				Expect(conf.EnableDBLock).To(Equal(true))
 			})
 		})
 
@@ -156,9 +166,9 @@ db:
 
 				Expect(conf.Lock.LockRetryInterval).To(Equal(DefaultRetryInterval))
 				Expect(conf.Lock.LockTTL).To(Equal(DefaultLockTTL))
+				Expect(conf.EnableDBLock).To(Equal(false))
 			})
 		})
-
 	})
 
 	Describe("Validate", func() {
@@ -173,6 +183,10 @@ db:
 			conf.Collector.CollectInterval = time.Duration(30 * time.Second)
 			conf.Collector.RefreshInterval = time.Duration(60 * time.Second)
 			conf.Collector.CollectMethod = CollectMethodPolling
+			conf.DBLock.LockDBURL = "postgres://pqgotest:password@exampl.com/pqgotest"
+			conf.DBLock.LockTTL = time.Duration(30 * time.Second)
+			conf.DBLock.Owner = "123456"
+			conf.EnableDBLock = true
 		})
 
 		JustBeforeEach(func() {
@@ -242,6 +256,39 @@ db:
 
 			It("should error", func() {
 				Expect(err).To(MatchError(MatchRegexp("Configuration error: invalid collecting method")))
+			})
+		})
+
+		Context("when lock db url is not set but dblock enabled", func() {
+			BeforeEach(func() {
+				conf.EnableDBLock = true
+				conf.DBLock.LockDBURL = ""
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock DB URL is empty")))
+			})
+		})
+
+		Context("when lock ttl is not set but dblock enabled ", func() {
+			BeforeEach(func() {
+				conf.EnableDBLock = true
+				conf.DBLock.LockTTL = time.Duration(0)
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock TTL is empty")))
+			})
+		})
+
+		Context("when lock owner is not set but dblock enabled", func() {
+			BeforeEach(func() {
+				conf.EnableDBLock = true
+				conf.DBLock.Owner = ""
+			})
+
+			It("should error", func() {
+				Expect(err).To(MatchError(MatchRegexp("Configuration error: Lock Owner is empty")))
 			})
 		})
 

--- a/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
+++ b/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
@@ -59,7 +59,7 @@ databaseChangeLog:
       author: paltanmoy
       changes:
         - createTable:
-            tableName: locks
+            tableName: mc_lock
             columns:
               - column:
                   name: owner

--- a/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
+++ b/src/autoscaler/metricscollector/db/metricscollector.db.changelog.yml
@@ -54,3 +54,26 @@ databaseChangeLog:
                  type: bigint                
              indexName: idx_instance_metrics
              tableName: appinstancemetrics
+  - changeSet:
+      id: 2
+      author: paltanmoy
+      changes:
+        - createTable:
+            tableName: locks
+            columns:
+              - column:
+                  name: owner
+                  type: varchar(255)
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: lock_timestamp
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ttl
+                  type: bigint
+                  defaultValue: 0
+                  constraints:
+                    nullable: false

--- a/src/autoscaler/metricscollector/exampleconfig/example.yml
+++ b/src/autoscaler/metricscollector/exampleconfig/example.yml
@@ -13,7 +13,12 @@ db:
 collector:
   refresh_interval: 30s
   collect_interval: 10s
-# lock:
-#   lock_ttl: 15s
-#   lock_retry_interval: 10s
-#   consul_cluster_config: http://127.0.0.1:8500
+#lock:
+#  lock_ttl: 15s
+#  lock_retry_interval: 10s
+#  consul_cluster_config: http://127.0.0.1:8500
+#db_lock:
+#  owner: 1234575
+#  ttl: 30s
+#  url: postgres://postgres:postgres@localhost/autoscaler?sslmode=disable
+#enable_db_lock: true

--- a/src/autoscaler/metricscollector/exampleconfig/example.yml
+++ b/src/autoscaler/metricscollector/exampleconfig/example.yml
@@ -18,7 +18,6 @@ collector:
 #  lock_retry_interval: 10s
 #  consul_cluster_config: http://127.0.0.1:8500
 #db_lock:
-#  owner: 1234575
 #  ttl: 30s
 #  url: postgres://postgres:postgres@localhost/autoscaler?sslmode=disable
 #enable_db_lock: true

--- a/src/autoscaler/models/lock.go
+++ b/src/autoscaler/models/lock.go
@@ -1,0 +1,11 @@
+package models
+
+import (
+	"time"
+)
+
+type Lock struct {
+	Owner                 string
+	LastModifiedTimestamp time.Time
+	Ttl                   time.Duration
+}

--- a/src/autoscaler/sync/dblock.go
+++ b/src/autoscaler/sync/dblock.go
@@ -1,0 +1,79 @@
+package sync
+
+import (
+	"autoscaler/db"
+	"autoscaler/models"
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+
+	"github.com/tedsuo/ifrit"
+)
+
+type DatabaseLock struct {
+	logger lager.Logger
+}
+
+func NewDatabaseLock(logger lager.Logger) *DatabaseLock {
+	return &DatabaseLock{
+		logger: logger,
+	}
+}
+
+func (dblock *DatabaseLock) InitDBLockRunner(ttl time.Duration, owner string, lockDB db.LockDB) ifrit.Runner {
+	dbLockMaintainer := ifrit.RunFunc(func(signals <-chan os.Signal, ready chan<- struct{}) error {
+		lockTicker := time.NewTicker(ttl)
+		readyFlag := true
+		if owner == "" {
+			dblock.logger.Info("failed-to-get-owner-details")
+			os.Exit(1)
+		}
+		lock := &models.Lock{Owner: owner, Ttl: ttl}
+		isLockAcquired, lockErr := lockDB.Lock(lock)
+		if lockErr != nil {
+			dblock.logger.Error("failed-to-acquire-lock-in-first-attempt", lockErr)
+		}
+		if isLockAcquired {
+			dblock.logger.Info("lock-acquired-in-first-attempt", lager.Data{"owner": owner, "isLockAcquired": isLockAcquired})
+			close(ready)
+			readyFlag = false
+		}
+		for {
+			select {
+			case <-signals:
+				dblock.logger.Info("received-interrupt-signal", lager.Data{"owner": owner})
+				lockTicker.Stop()
+				releaseErr := lockDB.Release(owner)
+				if releaseErr != nil {
+					dblock.logger.Error("failed-to-release-lock ", releaseErr)
+				} else {
+					dblock.logger.Info("successfully-released-lock", lager.Data{"owner": owner})
+				}
+				readyFlag = true
+				return nil
+
+			case <-lockTicker.C:
+				dblock.logger.Info("retry-acquiring-lock", lager.Data{"owner": owner})
+				lock := &models.Lock{Owner: owner, Ttl: ttl}
+				isLockAcquired, lockErr := lockDB.Lock(lock)
+				if lockErr != nil {
+					dblock.logger.Error("failed-to-acquire-lock", lockErr)
+					releaseErr := lockDB.Release(owner)
+					if releaseErr != nil {
+						dblock.logger.Error("failed-to-release-lock ", releaseErr)
+					} else {
+						dblock.logger.Info("successfully-released-lock", lager.Data{"owner": owner})
+					}
+					os.Exit(1)
+				}
+				if isLockAcquired && readyFlag {
+					close(ready)
+					readyFlag = false
+					dblock.logger.Info("successfully-acquired-lock", lager.Data{"owner": owner})
+				}
+			}
+		}
+	})
+	return dbLockMaintainer
+}

--- a/src/integration/components.go
+++ b/src/integration/components.go
@@ -345,7 +345,7 @@ spring.data.jpa.repositories.enabled=false
 	return cfgFile.Name()
 }
 
-func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port int, ccNOAAUAAUrl string, cfGrantTypePassword string, collectInterval time.Duration,
+func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port int, enableDBLock bool, ccNOAAUAAUrl string, cfGrantTypePassword string, collectInterval time.Duration,
 	refreshInterval time.Duration, collectMethod string, tmpDir string, lockTTL time.Duration, lockRetryInterval time.Duration, ConsulClusterConfig string) string {
 	cfg := mcConfig.Config{
 		Cf: cf.CfConfig{
@@ -378,6 +378,12 @@ func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port i
 			LockTTL:             lockTTL,
 			LockRetryInterval:   lockRetryInterval,
 			ConsulClusterConfig: ConsulClusterConfig,
+		},
+		EnableDBLock: enableDBLock,
+		DBLock: mcConfig.DBLockConfig{
+			Owner:     "123456",
+			LockTTL:   time.Duration(10 * time.Second),
+			LockDBURL: dbUri,
 		},
 	}
 

--- a/src/integration/components.go
+++ b/src/integration/components.go
@@ -381,8 +381,9 @@ func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port i
 		},
 		EnableDBLock: enableDBLock,
 		DBLock: mcConfig.DBLockConfig{
-			LockTTL:   time.Duration(10 * time.Second),
-			LockDBURL: dbUri,
+			LockTTL:           time.Duration(10 * time.Second),
+			LockDBURL:         dbUri,
+			LockRetryInterval: time.Duration(2 * time.Second),
 		},
 	}
 

--- a/src/integration/components.go
+++ b/src/integration/components.go
@@ -381,7 +381,6 @@ func (components *Components) PrepareMetricsCollectorConfig(dbUri string, port i
 		},
 		EnableDBLock: enableDBLock,
 		DBLock: mcConfig.DBLockConfig{
-			Owner:     "123456",
 			LockTTL:   time.Duration(10 * time.Second),
 			LockDBURL: dbUri,
 		},

--- a/src/integration/integration_api_metricscollector_test.go
+++ b/src/integration/integration_api_metricscollector_test.go
@@ -4,12 +4,13 @@ import (
 	"autoscaler/cf"
 	"autoscaler/metricscollector/config"
 	"autoscaler/models"
-	"code.cloudfoundry.org/locket"
 	"encoding/json"
 	"fmt"
 	. "integration"
 	"net/http"
 	"strings"
+
+	"code.cloudfoundry.org/locket"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,6 +33,7 @@ var _ = Describe("Integration_Api_MetricsCollector", func() {
 		metricType        string = "memoryused"
 		collectMethod     string = config.CollectMethodPolling
 		initInstanceCount int    = 2
+		enableDBLock      bool   = false
 	)
 
 	BeforeEach(func() {
@@ -39,7 +41,7 @@ var _ = Describe("Integration_Api_MetricsCollector", func() {
 		fakeMetricsPolling(appId, 400*1024*1024, 600*1024*1024)
 		initializeHttpClient("api.crt", "api.key", "autoscaler-ca.crt", apiMetricsCollectorHttpRequestTimeout)
 		initializeHttpClientForPublicApi("api_public.crt", "api_public.key", "autoscaler-ca.crt", apiMetricsCollectorHttpRequestTimeout)
-		metricsCollectorConfPath = components.PrepareMetricsCollectorConfig(dbUrl, components.Ports[MetricsCollector], fakeCCNOAAUAA.URL(), cf.GrantTypePassword, collectInterval,
+		metricsCollectorConfPath = components.PrepareMetricsCollectorConfig(dbUrl, components.Ports[MetricsCollector], enableDBLock, fakeCCNOAAUAA.URL(), cf.GrantTypePassword, collectInterval,
 			refreshInterval, collectMethod, tmpDir, locket.DefaultSessionTTL, locket.RetryInterval, consulRunner.ConsulCluster())
 		startMetricsCollector()
 

--- a/src/integration/integration_metricscollector_eventgenerator_scalingengine_test.go
+++ b/src/integration/integration_metricscollector_eventgenerator_scalingengine_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"autoscaler/metricscollector/config"
+
 	"code.cloudfoundry.org/locket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -22,6 +23,7 @@ var _ = Describe("Integration_Metricscollector_Eventgenerator_Scalingengine", fu
 		timeout           time.Duration = 20 * time.Second
 		initInstanceCount int           = 2
 		collectMethod     string        = config.CollectMethodPolling
+		enableDBLock      bool          = false
 	)
 	BeforeEach(func() {
 		testAppId = getRandomId()
@@ -29,7 +31,7 @@ var _ = Describe("Integration_Metricscollector_Eventgenerator_Scalingengine", fu
 	})
 
 	JustBeforeEach(func() {
-		metricsCollectorConfPath = components.PrepareMetricsCollectorConfig(dbUrl, components.Ports[MetricsCollector], fakeCCNOAAUAA.URL(), cf.GrantTypePassword, collectInterval,
+		metricsCollectorConfPath = components.PrepareMetricsCollectorConfig(dbUrl, components.Ports[MetricsCollector], enableDBLock, fakeCCNOAAUAA.URL(), cf.GrantTypePassword, collectInterval,
 			refreshInterval, collectMethod, tmpDir, locket.DefaultSessionTTL, locket.RetryInterval, consulRunner.ConsulCluster())
 		eventGeneratorConfPath = components.PrepareEventGeneratorConfig(dbUrl, fmt.Sprintf("https://127.0.0.1:%d", components.Ports[MetricsCollector]), fmt.Sprintf("https://127.0.0.1:%d", components.Ports[ScalingEngine]), aggregatorExecuteInterval, policyPollerInterval, evaluationManagerInterval, tmpDir, locket.DefaultSessionTTL, locket.RetryInterval, consulRunner.ConsulCluster())
 		scalingEngineConfPath = components.PrepareScalingEngineConfig(dbUrl, components.Ports[ScalingEngine], fakeCCNOAAUAA.URL(), cf.GrantTypePassword, tmpDir, consulRunner.ConsulCluster())
@@ -42,206 +44,424 @@ var _ = Describe("Integration_Metricscollector_Eventgenerator_Scalingengine", fu
 	AfterEach(func() {
 		stopAll()
 	})
-	Describe("Scale out", func() {
-		Context("application's metrics break the scaling out rule for more than breach duration", func() {
-			BeforeEach(func() {
-				testPolicy := models.ScalingPolicy{
-					InstanceMin: 1,
-					InstanceMax: 5,
-					ScalingRules: []*models.ScalingRule{
-						{
-							MetricType:            models.MetricNameMemoryUtil,
-							StatWindowSeconds:     10,
-							BreachDurationSeconds: 10,
-							Threshold:             30,
-							Operator:              ">=",
-							CoolDownSeconds:       10,
-							Adjustment:            "+1",
-						},
-					},
-				}
-				policyBytes, err := json.Marshal(testPolicy)
-				Expect(err).NotTo(HaveOccurred())
-				insertPolicy(testAppId, string(policyBytes), "1234")
-			})
-			Context("when using polling for metrics collection", func() {
-				BeforeEach(func() {
-					fakeMetricsPolling(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodPolling
-				})
-				It("should scale out", func() {
-					Eventually(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
-					}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
-				})
-			})
 
-			Context("when using streaming for metrics collection", func() {
-				BeforeEach(func() {
-					fakeMetricsStreaming(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodStreaming
-				})
-				AfterEach(func() {
-					closeFakeMetricsStreaming()
-				})
-				It("should scale out", func() {
-					Eventually(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
-					}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
-				})
-			})
+	Describe("Using consul based lock", func() {
 
+		BeforeEach(func() {
+			enableDBLock = false
 		})
-		Context("application's metrics do not break the scaling out rule", func() {
-			BeforeEach(func() {
-				testPolicy := models.ScalingPolicy{
-					InstanceMin: 1,
-					InstanceMax: 5,
-					ScalingRules: []*models.ScalingRule{
-						{
-							MetricType:            models.MetricNameMemoryUtil,
-							StatWindowSeconds:     10,
-							BreachDurationSeconds: 10,
-							Threshold:             80,
-							Operator:              ">=",
-							CoolDownSeconds:       10,
-							Adjustment:            "+1",
+
+		Describe("Scale out", func() {
+			Context("application's metrics break the scaling out rule for more than breach duration", func() {
+				BeforeEach(func() {
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             30,
+								Operator:              ">=",
+								CoolDownSeconds:       10,
+								Adjustment:            "+1",
+							},
 						},
-					},
-				}
-				policyBytes, err := json.Marshal(testPolicy)
-				Expect(err).NotTo(HaveOccurred())
-				insertPolicy(testAppId, string(policyBytes), "1234")
-			})
-			Context("when using polling for metrics collection", func() {
-				BeforeEach(func() {
-					fakeMetricsPolling(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodPolling
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
 				})
-				It("shouldn't scale out", func() {
-					Consistently(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
-					}, timeout, 1*time.Second).Should(Equal(0))
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("should scale out", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
 				})
-			})
 
-			Context("when using streaming for metrics collection", func() {
-				BeforeEach(func() {
-					fakeMetricsStreaming(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodStreaming
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("should scale out", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
 				})
-				AfterEach(func() {
-					closeFakeMetricsStreaming()
-				})
-				It("shouldn't scale out", func() {
-					Consistently(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
-					}, timeout, 1*time.Second).Should(Equal(0))
-				})
-			})
 
+			})
+			Context("application's metrics do not break the scaling out rule", func() {
+				BeforeEach(func() {
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             80,
+								Operator:              ">=",
+								CoolDownSeconds:       10,
+								Adjustment:            "+1",
+							},
+						},
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
+				})
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("shouldn't scale out", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("shouldn't scale out", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+			})
+		})
+		Describe("Scale in", func() {
+			Context("application's metrics break the scaling in rule for more than breach duration", func() {
+				BeforeEach(func() {
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             80,
+								Operator:              "<",
+								CoolDownSeconds:       10,
+								Adjustment:            "-1",
+							},
+						},
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
+				})
+
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("should scale in", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
+				})
+
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("should scale in", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
+				})
+
+			})
+			Context("application's metrics do not break the scaling in rule", func() {
+				BeforeEach(func() {
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             30,
+								Operator:              "<",
+								CoolDownSeconds:       30,
+								Adjustment:            "-1",
+							},
+						},
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
+				})
+
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("shouldn't scale in", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("shouldn't scale in", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+			})
 		})
 	})
-	Describe("Scale in", func() {
-		Context("application's metrics break the scaling in rule for more than breach duration", func() {
-			BeforeEach(func() {
-				testPolicy := models.ScalingPolicy{
-					InstanceMin: 1,
-					InstanceMax: 5,
-					ScalingRules: []*models.ScalingRule{
-						{
-							MetricType:            models.MetricNameMemoryUtil,
-							StatWindowSeconds:     10,
-							BreachDurationSeconds: 10,
-							Threshold:             80,
-							Operator:              "<",
-							CoolDownSeconds:       10,
-							Adjustment:            "-1",
-						},
-					},
-				}
-				policyBytes, err := json.Marshal(testPolicy)
-				Expect(err).NotTo(HaveOccurred())
-				insertPolicy(testAppId, string(policyBytes), "1234")
-			})
 
-			Context("when using polling for metrics collection", func() {
-				BeforeEach(func() {
-					fakeMetricsPolling(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodPolling
-				})
-				It("should scale in", func() {
-					Eventually(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
-					}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
-				})
-			})
+	Describe("Using database lock", func() {
 
-			Context("when using streaming for metrics collection", func() {
-				BeforeEach(func() {
-					fakeMetricsStreaming(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodStreaming
-				})
-				AfterEach(func() {
-					closeFakeMetricsStreaming()
-				})
-				It("should scale in", func() {
-					Eventually(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
-					}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
-				})
-			})
-
+		BeforeEach(func() {
+			enableDBLock = true
 		})
-		Context("application's metrics do not break the scaling in rule", func() {
-			BeforeEach(func() {
-				testPolicy := models.ScalingPolicy{
-					InstanceMin: 1,
-					InstanceMax: 5,
-					ScalingRules: []*models.ScalingRule{
-						{
-							MetricType:            models.MetricNameMemoryUtil,
-							StatWindowSeconds:     10,
-							BreachDurationSeconds: 10,
-							Threshold:             30,
-							Operator:              "<",
-							CoolDownSeconds:       30,
-							Adjustment:            "-1",
+
+		Describe("Scale out", func() {
+			Context("application's metrics break the scaling out rule for more than breach duration", func() {
+				BeforeEach(func() {
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             30,
+								Operator:              ">=",
+								CoolDownSeconds:       10,
+								Adjustment:            "+1",
+							},
 						},
-					},
-				}
-				policyBytes, err := json.Marshal(testPolicy)
-				Expect(err).NotTo(HaveOccurred())
-				insertPolicy(testAppId, string(policyBytes), "1234")
-			})
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
+				})
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("should scale out", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
+				})
 
-			Context("when using polling for metrics collection", func() {
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("should scale out", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
+				})
+
+			})
+			Context("application's metrics do not break the scaling out rule", func() {
 				BeforeEach(func() {
-					fakeMetricsPolling(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodPolling
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             80,
+								Operator:              ">=",
+								CoolDownSeconds:       10,
+								Adjustment:            "+1",
+							},
+						},
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
 				})
-				It("shouldn't scale in", func() {
-					Consistently(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
-					}, timeout, 1*time.Second).Should(Equal(0))
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("shouldn't scale out", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
 				})
-			})
 
-			Context("when using streaming for metrics collection", func() {
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("shouldn't scale out", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount+1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+			})
+		})
+		Describe("Scale in", func() {
+			Context("application's metrics break the scaling in rule for more than breach duration", func() {
 				BeforeEach(func() {
-					fakeMetricsStreaming(testAppId, 102400000, 204800000)
-					collectMethod = config.CollectMethodStreaming
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             80,
+								Operator:              "<",
+								CoolDownSeconds:       10,
+								Adjustment:            "-1",
+							},
+						},
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
 				})
-				AfterEach(func() {
-					closeFakeMetricsStreaming()
-				})
-				It("shouldn't scale in", func() {
-					Consistently(func() int {
-						return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
-					}, timeout, 1*time.Second).Should(Equal(0))
-				})
-			})
 
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("should scale in", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
+				})
+
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("should scale in", func() {
+						Eventually(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(BeNumerically(">=", 1))
+					})
+				})
+
+			})
+			Context("application's metrics do not break the scaling in rule", func() {
+				BeforeEach(func() {
+					testPolicy := models.ScalingPolicy{
+						InstanceMin: 1,
+						InstanceMax: 5,
+						ScalingRules: []*models.ScalingRule{
+							{
+								MetricType:            models.MetricNameMemoryUtil,
+								StatWindowSeconds:     10,
+								BreachDurationSeconds: 10,
+								Threshold:             30,
+								Operator:              "<",
+								CoolDownSeconds:       30,
+								Adjustment:            "-1",
+							},
+						},
+					}
+					policyBytes, err := json.Marshal(testPolicy)
+					Expect(err).NotTo(HaveOccurred())
+					insertPolicy(testAppId, string(policyBytes), "1234")
+				})
+
+				Context("when using polling for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsPolling(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodPolling
+					})
+					It("shouldn't scale in", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+				Context("when using streaming for metrics collection", func() {
+					BeforeEach(func() {
+						fakeMetricsStreaming(testAppId, 102400000, 204800000)
+						collectMethod = config.CollectMethodStreaming
+					})
+					AfterEach(func() {
+						closeFakeMetricsStreaming()
+					})
+					It("shouldn't scale in", func() {
+						Consistently(func() int {
+							return getScalingHistoryCount(testAppId, initInstanceCount, initInstanceCount-1)
+						}, timeout, 1*time.Second).Should(Equal(0))
+					})
+				})
+
+			})
 		})
 	})
 })


### PR DESCRIPTION
- Implemented database lock to achieve singleton for metricscolletor without using consul (Need to enable this feature by setting enable_db_lock to true)

- Added unit tests

- Modified Integration tests