### PR TITLE
Fixing Travis CI Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
 
-# App-AutoScaler [![Build Status](https://travis-ci.org/cloudfoundry-incubator/app-autoscaler.svg?branch=graceful_shutdown)](https://travis-ci.org/cloudfoundry-incubator/app-autoscaler)
+# App-AutoScaler [![Build Status](https://travis-ci.org/cloudfoundry-incubator/app-autoscaler.svg?branch=develop)](https://travis-ci.org/cloudfoundry-incubator/app-autoscaler)
 
 This is an incubation project for Cloud Foundry. You can follow the development progress on [Pivotal Tracker][t].
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
-[![Build Status](https://runtime-og.ci.cf-app.com/api/v1/pipelines/autoscaler/jobs/unit-tests/badge?ts=1)](https://runtime-og.ci.cf-app.com/pipelines/autoscaler)
 
-# App-AutoScaler
+# App-AutoScaler [![Build Status](https://travis-ci.org/cloudfoundry-incubator/app-autoscaler.svg?branch=graceful_shutdown)](https://travis-ci.org/cloudfoundry-incubator/app-autoscaler)
 
 This is an incubation project for Cloud Foundry. You can follow the development progress on [Pivotal Tracker][t].
 


### PR DESCRIPTION
- Deleting the old link which is no longer accessible.
- Adding a build stats badge to this project 

![screenshot from 2017-09-14 14-05-26](https://user-images.githubusercontent.com/16567880/30412899-e120da8c-9955-11e7-9262-efc83de73de1.png)
