### PR TITLE
api server fails to connect to Cloud controller on bosh-lite

### DIFF
--- a/api/lib/oauth/oauth.js
+++ b/api/lib/oauth/oauth.js
@@ -31,6 +31,7 @@ module.exports = function(configFilePath) {
           method: "GET",
           json: true,
           timeout: 10000,
+          rejectUnauthorized: false,   
           headers: {
             "Authorization": userToken,
             "Content-Type": "application/json"
@@ -79,7 +80,7 @@ module.exports = function(configFilePath) {
       method: "GET",
       json: true,
       timeout: 10000,
-
+      rejectUnauthorized: false,
     };
     request(options, function(error, response, body) {
       if (error) {
@@ -107,6 +108,7 @@ module.exports = function(configFilePath) {
       method: "GET",
       json: true,
       timeout: 10000,
+      rejectUnauthorized: false, 
       headers: {
         "Authorization": userToken,
         "Content-Type": "application/json"


### PR DESCRIPTION
[#151365570]
. skip the TLS validation when connect to cc & aaa
. a prerequiete for PR
https://github.com/cloudfoundry-incubator/app-autoscaler-release/pull/81