### PR TITLE
add include=all parameter in scaling history api, only return succedd…

### DIFF
--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -41,7 +41,7 @@ type AppMetricDB interface {
 
 type ScalingEngineDB interface {
 	SaveScalingHistory(history *models.AppScalingHistory) error
-	RetrieveScalingHistories(appId string, start int64, end int64, orderType OrderType) ([]*models.AppScalingHistory, error)
+	RetrieveScalingHistories(appId string, start int64, end int64, orderType OrderType, includeAll bool) ([]*models.AppScalingHistory, error)
 	PruneScalingHistories(before int64) error
 	UpdateScalingCooldownExpireTime(appId string, expireAt int64) error
 	CanScaleApp(appId string) (bool, error)

--- a/src/autoscaler/scalingengine/fakes/fake_scalingengine_db.go
+++ b/src/autoscaler/scalingengine/fakes/fake_scalingengine_db.go
@@ -19,13 +19,14 @@ type FakeScalingEngineDB struct {
 	saveScalingHistoryReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RetrieveScalingHistoriesStub        func(appId string, start int64, end int64, orderType db.OrderType) ([]*models.AppScalingHistory, error)
+	RetrieveScalingHistoriesStub        func(appId string, start int64, end int64, orderType db.OrderType, includeAll bool) ([]*models.AppScalingHistory, error)
 	retrieveScalingHistoriesMutex       sync.RWMutex
 	retrieveScalingHistoriesArgsForCall []struct {
-		appId     string
-		start     int64
-		end       int64
-		orderType db.OrderType
+		appId      string
+		start      int64
+		end        int64
+		orderType  db.OrderType
+		includeAll bool
 	}
 	retrieveScalingHistoriesReturns struct {
 		result1 []*models.AppScalingHistory
@@ -179,19 +180,20 @@ func (fake *FakeScalingEngineDB) SaveScalingHistoryReturnsOnCall(i int, result1 
 	}{result1}
 }
 
-func (fake *FakeScalingEngineDB) RetrieveScalingHistories(appId string, start int64, end int64, orderType db.OrderType) ([]*models.AppScalingHistory, error) {
+func (fake *FakeScalingEngineDB) RetrieveScalingHistories(appId string, start int64, end int64, orderType db.OrderType, includeAll bool) ([]*models.AppScalingHistory, error) {
 	fake.retrieveScalingHistoriesMutex.Lock()
 	ret, specificReturn := fake.retrieveScalingHistoriesReturnsOnCall[len(fake.retrieveScalingHistoriesArgsForCall)]
 	fake.retrieveScalingHistoriesArgsForCall = append(fake.retrieveScalingHistoriesArgsForCall, struct {
-		appId     string
-		start     int64
-		end       int64
-		orderType db.OrderType
-	}{appId, start, end, orderType})
-	fake.recordInvocation("RetrieveScalingHistories", []interface{}{appId, start, end, orderType})
+		appId      string
+		start      int64
+		end        int64
+		orderType  db.OrderType
+		includeAll bool
+	}{appId, start, end, orderType, includeAll})
+	fake.recordInvocation("RetrieveScalingHistories", []interface{}{appId, start, end, orderType, includeAll})
 	fake.retrieveScalingHistoriesMutex.Unlock()
 	if fake.RetrieveScalingHistoriesStub != nil {
-		return fake.RetrieveScalingHistoriesStub(appId, start, end, orderType)
+		return fake.RetrieveScalingHistoriesStub(appId, start, end, orderType, includeAll)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -205,10 +207,10 @@ func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesCallCount() int {
 	return len(fake.retrieveScalingHistoriesArgsForCall)
 }
 
-func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesArgsForCall(i int) (string, int64, int64, db.OrderType) {
+func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesArgsForCall(i int) (string, int64, int64, db.OrderType, bool) {
 	fake.retrieveScalingHistoriesMutex.RLock()
 	defer fake.retrieveScalingHistoriesMutex.RUnlock()
-	return fake.retrieveScalingHistoriesArgsForCall[i].appId, fake.retrieveScalingHistoriesArgsForCall[i].start, fake.retrieveScalingHistoriesArgsForCall[i].end, fake.retrieveScalingHistoriesArgsForCall[i].orderType
+	return fake.retrieveScalingHistoriesArgsForCall[i].appId, fake.retrieveScalingHistoriesArgsForCall[i].start, fake.retrieveScalingHistoriesArgsForCall[i].end, fake.retrieveScalingHistoriesArgsForCall[i].orderType, fake.retrieveScalingHistoriesArgsForCall[i].includeAll
 }
 
 func (fake *FakeScalingEngineDB) RetrieveScalingHistoriesReturns(result1 []*models.AppScalingHistory, result2 error) {


### PR DESCRIPTION
…ed and failed history by default

[#151547679]

- db pacakge changes to add includeAll flag when retrieving scaling history
- add include parameter in scaling history api
- regenerate fakes due to interface change