### PR TITLE
Add in CPU percentage data for scaling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /.project
 /.settings/
 *.coverprofile
+npm-shrinkwrap.json
+src/autoscaler/metricscollector/metricscollector

--- a/api/lib/validation/schemaValidator.js
+++ b/api/lib/validation/schemaValidator.js
@@ -57,7 +57,7 @@ var getDaysInMonthInISOFormat = function() {
 };
 
 var getMetricTypes = function() {
-  var metricTypeEnum = ['memoryused', 'memoryutil', 'responsetime', 'throughput'];
+  var metricTypeEnum = ['memoryused', 'memoryutil', 'responsetime', 'throughput', 'cpuPercentage'];
   return metricTypeEnum;
 };
 

--- a/src/autoscaler/metricscollector/README.md
+++ b/src/autoscaler/metricscollector/README.md
@@ -1,6 +1,6 @@
 #Metrics Collector
 
-Metrics Collector is one of the components of CF `app-autoscaler`. It is used to collect application metrics from CF loggretator. The current version only supports memory metrics, it will be extended to include other metrics like throughput and response time at a later time.
+Metrics Collector is one of the components of CF `app-autoscaler`. It is used to collect application metrics from CF loggretator. The current version only supports memory metrics and cpuPercentage, it will be extended to include other metrics like throughput and response time at a later time.
 
 ## Getting started
 

--- a/src/autoscaler/metricscollector/collector/app_streamer.go
+++ b/src/autoscaler/metricscollector/collector/app_streamer.go
@@ -111,7 +111,14 @@ func (as *appStreamer) processEvent(event *events.Envelope) {
 				as.logger.Error("process-event-save-metric", err, lager.Data{"metric": metric})
 			}
 		}
-
+		metric = noaa.GetInstanceCpuPercentageMetricFromContainerMetricEvent(as.sclock.Now().UnixNano(), as.appId, event)
+		as.logger.Debug("process-event-get-cpupercentage-metric", lager.Data{"metric": metric})
+		if metric != nil {
+			err := as.database.SaveMetric(metric)
+			if err != nil {
+				as.logger.Error("process-event-save-metric", err, lager.Data{"metric": metric})
+			}
+		}
 	} else if event.GetEventType() == events.Envelope_HttpStartStop {
 		as.logger.Debug("process-event-get-httpstartstop-event", lager.Data{"event": event})
 		ss := event.GetHttpStartStop()

--- a/src/autoscaler/metricscollector/collector/app_streamer_test.go
+++ b/src/autoscaler/metricscollector/collector/app_streamer_test.go
@@ -73,7 +73,7 @@ var _ = Describe("AppStreamer", func() {
 				}()
 			})
 			It("Saves memory and throughput metrics to database", func() {
-				Eventually(database.SaveMetricCallCount).Should(Equal(4))
+				Eventually(database.SaveMetricCallCount).Should(Equal(6))
 				Expect(database.SaveMetricArgsForCall(0)).To(Equal(&models.AppInstanceMetric{
 					AppId:         "an-app-id",
 					InstanceIndex: 0,
@@ -95,6 +95,16 @@ var _ = Describe("AppStreamer", func() {
 
 				Expect(database.SaveMetricArgsForCall(2)).To(Equal(&models.AppInstanceMetric{
 					AppId:         "an-app-id",
+					InstanceIndex: 0,
+					CollectedAt:   fclock.Now().UnixNano(),
+					Name:          models.MetricNameCpuPercentage,
+					Unit:          models.UnitPercentage,
+					Value:         "13",
+					Timestamp:     111111,
+				}))
+
+				Expect(database.SaveMetricArgsForCall(3)).To(Equal(&models.AppInstanceMetric{
+					AppId:         "an-app-id",
 					InstanceIndex: 1,
 					CollectedAt:   fclock.Now().UnixNano(),
 					Name:          models.MetricNameMemoryUsed,
@@ -103,7 +113,7 @@ var _ = Describe("AppStreamer", func() {
 					Timestamp:     222222,
 				}))
 
-				Expect(database.SaveMetricArgsForCall(3)).To(Equal(&models.AppInstanceMetric{
+				Expect(database.SaveMetricArgsForCall(4)).To(Equal(&models.AppInstanceMetric{
 					AppId:         "an-app-id",
 					InstanceIndex: 1,
 					CollectedAt:   fclock.Now().UnixNano(),
@@ -113,13 +123,23 @@ var _ = Describe("AppStreamer", func() {
 					Timestamp:     222222,
 				}))
 
+				Expect(database.SaveMetricArgsForCall(5)).To(Equal(&models.AppInstanceMetric{
+					AppId:         "an-app-id",
+					InstanceIndex: 1,
+					CollectedAt:   fclock.Now().UnixNano(),
+					Name:          models.MetricNameCpuPercentage,
+					Unit:          models.UnitPercentage,
+					Value:         "31",
+					Timestamp:     222222,
+				}))
+
 				By("collecting and computing throughput")
-				Consistently(database.SaveMetricCallCount).Should(Equal(4))
+				Consistently(database.SaveMetricCallCount).Should(Equal(6))
 
 				By("save throughput after the collect interval")
 				fclock.WaitForWatcherAndIncrement(TestCollectInterval)
-				Eventually(database.SaveMetricCallCount).Should(Equal(5))
-				Expect(database.SaveMetricArgsForCall(4)).To(Equal(&models.AppInstanceMetric{
+				Eventually(database.SaveMetricCallCount).Should(Equal(7))
+				Expect(database.SaveMetricArgsForCall(6)).To(Equal(&models.AppInstanceMetric{
 					AppId:         "an-app-id",
 					InstanceIndex: 0,
 					CollectedAt:   fclock.Now().UnixNano(),

--- a/src/autoscaler/metricscollector/collector/apppoller.go
+++ b/src/autoscaler/metricscollector/collector/apppoller.go
@@ -83,7 +83,7 @@ func (ap *appPoller) pollMetric() {
 
 	logger.Debug("poll-metric-get-containerenvelopes", lager.Data{"envelops": containerEnvelopes})
 
-	metrics := noaa.GetInstanceMemoryMetricsFromContainerEnvelopes(ap.pclock.Now().UnixNano(), ap.appId, containerEnvelopes)
+	metrics := noaa.GetInstanceMetricsFromContainerEnvelopes(ap.pclock.Now().UnixNano(), ap.appId, containerEnvelopes)
 	logger.Debug("poll-metric-get-memory-metrics", lager.Data{"metrics": metrics})
 
 	for _, metric := range metrics {

--- a/src/autoscaler/models/metrics.go
+++ b/src/autoscaler/models/metrics.go
@@ -8,6 +8,7 @@ const (
 	UnitRPS          = "rps"
 )
 
+const MetricNameCpuPercentage = "cpuPercentage"
 const MetricNameMemoryUtil = "memoryutil"
 const MetricNameMemoryUsed = "memoryused"
 const MetricNameThroughput = "throughput"


### PR DESCRIPTION
## What

We found that the existing set of metrics supported by the autoscaler was not suitable for our workloads. Most of our apps are java containers and they do not release the memory back to the operating system, so attempting to scale applications based on memory consumption resulted in all apps always being scaled to the max instances and never being scaled back down again.

We noticed that you had a spike in your Pivotal Tracker for adding the CPU scaling back in again.
 https://www.pivotaltracker.com/story/show/144124793 - The ticket in your tracker makes some noises about Diego being able to enforce CPU quotas - We checked and it still doesn't do that - It just uses a best-effort fairness algorithm to try and ensure that all containers get some CPU from time to time, so noisy neighbours may still have an impact on the CPU metrics emitted (i.e. never able to reach 100% CPU usage in a container because other containers are already using the CPU)

We understand that the CPU metric was removed in 2015 as the CPU metrics emitted from diego cells are not normalised to take account of the number of CPUs present - https://developer.ibm.com/answers/questions/211364/changes-to-bluemix-auto-scaling-service-metric-cpu/ - However, for our particular use case, all of our diego cells are identically sized so normalisation of the CPU metrics is not essential.

## Features:
- Store the cm.GetCpuPercentage value into the database as cpuPercentage
- Allow cpuPercentage to be a valid entry in the schema
- Add tests for the new code.
- update the readme

We thought we'd fire a PR off over to you to see if you'd like to merge in these changes.