### PR TITLE
remove -p in integration test in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ popd
 
 go install github.com/onsi/ginkgo/ginkgo
 export DBURL=postgres://postgres@localhost/autoscaler?sslmode=disable
-ginkgo -r -race -p -randomizeAllSpecs src/integration
+ginkgo -r -race -randomizeAllSpecs src/integration
 ```
 
 ## Deploy and use


### PR DESCRIPTION
we don't support run scheduler-scalingengine integration test in parallel