### PR TITLE
#151855308 : Redacting sensitive data in the logs

### DIFF
--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
@@ -150,7 +150,14 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 		os.Exit(1)
 	}
 	logger := lager.NewLogger("eventgenerator")
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, logLevel))
+
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+
+	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
+	}
+	logger.RegisterSink(redactedSink)
 
 	return logger
 }

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
@@ -7,6 +7,7 @@ import (
 	"autoscaler/eventgenerator/aggregator"
 	"autoscaler/eventgenerator/config"
 	"autoscaler/eventgenerator/generator"
+	alogger "autoscaler/logger"
 	"autoscaler/models"
 	"flag"
 	"fmt"
@@ -151,9 +152,9 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 	}
 	logger := lager.NewLogger("eventgenerator")
 
-	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken"}
 
-	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	redactedSink, err := alogger.NewRedactingWriterWithURLCredSink(os.Stdout, logLevel, keyPatterns, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
 	}

--- a/src/autoscaler/logger/json_redacter_with_url_creds.go
+++ b/src/autoscaler/logger/json_redacter_with_url_creds.go
@@ -1,0 +1,84 @@
+package logger
+
+import (
+	"encoding/json"
+	"regexp"
+
+	"code.cloudfoundry.org/lager"
+)
+
+const postgresDbURLPattern = `^(postgres|postgresql):\/\/(.+):(.+)@([\da-zA-Z\.-]+)(:[\d]{4,5})?\/(.+)`
+
+type JSONRedacterWithURLCred struct {
+	jsonRedacter   *lager.JSONRedacter
+	urlCredMatcher *regexp.Regexp
+}
+
+func NewJSONRedacterWithURLCred(keyPatterns []string, valuePatterns []string) (*JSONRedacterWithURLCred, error) {
+	jsonRedacter, err := lager.NewJSONRedacter(keyPatterns, valuePatterns)
+	if err != nil {
+		return nil, err
+	}
+	urlCredMatcher, err := regexp.Compile(postgresDbURLPattern)
+	return &JSONRedacterWithURLCred{
+		jsonRedacter:   jsonRedacter,
+		urlCredMatcher: urlCredMatcher,
+	}, nil
+}
+
+func (r JSONRedacterWithURLCred) Redact(data []byte) []byte {
+	var jsonBlob interface{}
+	err := json.Unmarshal(data, &jsonBlob)
+	if err != nil {
+		return handleError(err)
+	}
+	r.redactValue(&jsonBlob)
+
+	data, err = json.Marshal(jsonBlob)
+	if err != nil {
+		return handleError(err)
+	}
+
+	return r.jsonRedacter.Redact(data)
+}
+
+func (r JSONRedacterWithURLCred) redactValue(data *interface{}) interface{} {
+	if data == nil {
+		return data
+	}
+
+	if a, ok := (*data).([]interface{}); ok {
+		r.redactArray(&a)
+	} else if m, ok := (*data).(map[string]interface{}); ok {
+		r.redactObject(&m)
+	} else if s, ok := (*data).(string); ok {
+		if r.urlCredMatcher.MatchString(s) {
+			(*data) = r.urlCredMatcher.ReplaceAllString(s, `$1://$2:*REDACTED*@$4$5/$6`)
+		}
+	}
+	return (*data)
+}
+
+func (r JSONRedacterWithURLCred) redactArray(data *[]interface{}) {
+	for i, _ := range *data {
+		r.redactValue(&((*data)[i]))
+	}
+}
+
+func (r JSONRedacterWithURLCred) redactObject(data *map[string]interface{}) {
+	for k, v := range *data {
+		(*data)[k] = r.redactValue(&v)
+	}
+}
+
+func handleError(err error) []byte {
+	var content []byte
+	if _, ok := err.(*json.UnsupportedTypeError); ok {
+		data := map[string]interface{}{"lager serialisation error": err.Error()}
+		content, err = json.Marshal(data)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return content
+}

--- a/src/autoscaler/logger/json_redacter_with_url_creds_test.go
+++ b/src/autoscaler/logger/json_redacter_with_url_creds_test.go
@@ -1,0 +1,69 @@
+package logger_test
+
+import (
+	"autoscaler/logger"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JSON Redacter With URL Cred", func() {
+	var (
+		resp         []byte
+		err          error
+		jsonRedacter *logger.JSONRedacterWithURLCred
+	)
+
+	BeforeEach(func() {
+		jsonRedacter, err = logger.NewJSONRedacterWithURLCred([]string{"[Pp]wd", "[Pp]ass"}, []string{`AKIA[A-Z0-9]{16}`})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when called with normal (non-secret) json", func() {
+		BeforeEach(func() {
+			resp = jsonRedacter.Redact([]byte(`{"foo":"bar","url":"https://api.bosh-lite.com"}`))
+		})
+		It("should return the same text", func() {
+			Expect(resp).To(Equal([]byte(`{"foo":"bar","url":"https://api.bosh-lite.com"}`)))
+		})
+	})
+
+	Context("when called with postgres db url with credentials", func() {
+		BeforeEach(func() {
+			resp = jsonRedacter.Redact([]byte(`{"dbURL":"postgresql://username:password@hostname:5432/dbname?sslmode=disabled","password":"secret!"}`))
+		})
+		It("Should only redact the password", func() {
+			Expect(resp).To(Equal([]byte(`{"dbURL":"postgresql://username:*REDACTED*@hostname:5432/dbname?sslmode=disabled","password":"*REDACTED*"}`)))
+		})
+	})
+
+	Context("when called with secrets inside the json", func() {
+		BeforeEach(func() {
+			resp = jsonRedacter.Redact([]byte(`{"foo":"fooval","password":"secret!","something":"AKIA1234567890123456"}`))
+		})
+
+		It("should redact the secrets", func() {
+			Expect(resp).To(Equal([]byte(`{"foo":"fooval","password":"*REDACTED*","something":"*REDACTED*"}`)))
+		})
+	})
+
+	Context("when a password flag is specified", func() {
+		BeforeEach(func() {
+			resp = jsonRedacter.Redact([]byte(`{"abcPwd":"abcd","password":"secret!","userpass":"fooval"}`))
+		})
+
+		It("should redact the secrets", func() {
+			Expect(resp).To(Equal([]byte(`{"abcPwd":"*REDACTED*","password":"*REDACTED*","userpass":"*REDACTED*"}`)))
+		})
+	})
+
+	Context("when called with an array of objects with a secret", func() {
+		BeforeEach(func() {
+			resp = jsonRedacter.Redact([]byte(`[{"dbURL":"postgresql://username:password@hostname:5432/dbname?sslmode=disabled","foo":"fooval","password":"secret!"}]`))
+		})
+
+		It("should redact the secrets", func() {
+			Expect(resp).To(Equal([]byte(`[{"dbURL":"postgresql://username:*REDACTED*@hostname:5432/dbname?sslmode=disabled","foo":"fooval","password":"*REDACTED*"}]`)))
+		})
+	})
+})

--- a/src/autoscaler/logger/logger_suite_test.go
+++ b/src/autoscaler/logger/logger_suite_test.go
@@ -1,0 +1,47 @@
+package logger_test
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logger Suite")
+}
+
+// copyWriter is an INTENTIONALLY UNSAFE writer. Use it to test code that
+// should be handling thread safety.
+type copyWriter struct {
+	contents []byte
+	lock     *sync.RWMutex
+}
+
+func NewCopyWriter() *copyWriter {
+	return &copyWriter{
+		contents: []byte{},
+		lock:     new(sync.RWMutex),
+	}
+}
+
+// no, we really mean RLock on write.
+func (writer *copyWriter) Write(p []byte) (n int, err error) {
+	writer.lock.RLock()
+	defer writer.lock.RUnlock()
+
+	writer.contents = append(writer.contents, p...)
+	return len(p), nil
+}
+
+func (writer *copyWriter) Copy() []byte {
+	writer.lock.Lock()
+	defer writer.lock.Unlock()
+
+	contents := make([]byte, len(writer.contents))
+	copy(contents, writer.contents)
+	return contents
+}

--- a/src/autoscaler/logger/redacting_writer_with_url_creds_sink.go
+++ b/src/autoscaler/logger/redacting_writer_with_url_creds_sink.go
@@ -1,0 +1,42 @@
+package logger
+
+import (
+	"io"
+	"sync"
+
+	"code.cloudfoundry.org/lager"
+)
+
+type redactingWriterWithURLCredSink struct {
+	writer                  io.Writer
+	minLogLevel             lager.LogLevel
+	writeL                  *sync.Mutex
+	jsonRedacterWithURLCred *JSONRedacterWithURLCred
+}
+
+func NewRedactingWriterWithURLCredSink(writer io.Writer, minLogLevel lager.LogLevel, keyPatterns []string, valuePatterns []string) (lager.Sink, error) {
+	jsonRedacterWithURLCred, err := NewJSONRedacterWithURLCred(keyPatterns, valuePatterns)
+	if err != nil {
+		return nil, err
+	}
+	return &redactingWriterWithURLCredSink{
+		writer:                  writer,
+		minLogLevel:             minLogLevel,
+		writeL:                  new(sync.Mutex),
+		jsonRedacterWithURLCred: jsonRedacterWithURLCred,
+	}, nil
+}
+
+func (sink *redactingWriterWithURLCredSink) Log(log lager.LogFormat) {
+	if log.LogLevel < sink.minLogLevel {
+		return
+	}
+
+	sink.writeL.Lock()
+	v := log.ToJSON()
+	rv := sink.jsonRedacterWithURLCred.Redact(v)
+
+	sink.writer.Write(rv)
+	sink.writer.Write([]byte("\n"))
+	sink.writeL.Unlock()
+}

--- a/src/autoscaler/logger/redacting_writer_with_url_creds_sink_test.go
+++ b/src/autoscaler/logger/redacting_writer_with_url_creds_sink_test.go
@@ -1,0 +1,89 @@
+package logger_test
+
+import (
+	"autoscaler/logger"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"code.cloudfoundry.org/lager"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RedactingWriterSinkWithUrlCred", func() {
+	const MaxThreads = 100
+
+	var sink lager.Sink
+	var writer *copyWriter
+
+	BeforeEach(func() {
+		writer = NewCopyWriter()
+		var err error
+		sink, err = logger.NewRedactingWriterWithURLCredSink(writer, lager.INFO, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when logging above the minimum log level", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: lager.Data{"password": "abcd", "dburl": "postgresql://username:password@hostname:5432/dbname?sslmode=disabled"}})
+		})
+
+		It("writes to the given writer", func() {
+			Expect(writer.Copy()).To(MatchJSON(`{"message":"hello world","log_level":1,"timestamp":"","source":"","data":{"password":"*REDACTED*","dburl":"postgresql://username:*REDACTED*@hostname:5432/dbname?sslmode=disabled"}}`))
+		})
+	})
+
+	Context("when a unserializable object is passed into data", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: map[string]interface{}{"some_key": func() {}}})
+		})
+
+		It("logs the serialization error", func() {
+			message := map[string]interface{}{}
+			json.Unmarshal(writer.Copy(), &message)
+			Expect(message["message"]).To(Equal("hello world"))
+			Expect(message["log_level"]).To(Equal(float64(1)))
+			Expect(message["data"].(map[string]interface{})["lager serialisation error"]).To(Equal("json: unsupported type: func()"))
+			Expect(message["data"].(map[string]interface{})["data_dump"]).ToNot(BeEmpty())
+		})
+	})
+
+	Context("when logging below the minimum log level", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.DEBUG, Message: "hello world"})
+		})
+
+		It("does not write to the given writer", func() {
+			Expect(writer.Copy()).To(Equal([]byte{}))
+		})
+	})
+
+	Context("when logging from multiple threads", func() {
+		var content = "abcdefg "
+
+		BeforeEach(func() {
+			wg := new(sync.WaitGroup)
+			for i := 0; i < MaxThreads; i++ {
+				wg.Add(1)
+				go func() {
+					sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: content})
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		})
+
+		It("writes to the given writer", func() {
+			lines := strings.Split(string(writer.Copy()), "\n")
+			for _, line := range lines {
+				if line == "" {
+					continue
+				}
+				Expect(line).To(MatchJSON(fmt.Sprintf(`{"message":"%s","log_level":1,"timestamp":"","source":"","data":null}`, content)))
+			}
+		})
+	})
+})

--- a/src/autoscaler/metricscollector/cmd/metricscollector/main.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/main.go
@@ -10,6 +10,7 @@ import (
 	"autoscaler/cf"
 	"autoscaler/db"
 	"autoscaler/db/sqldb"
+	alogger "autoscaler/logger"
 	"autoscaler/metricscollector"
 	"autoscaler/metricscollector/collector"
 	"autoscaler/metricscollector/config"
@@ -190,9 +191,9 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 	}
 	logger := lager.NewLogger("metricscollector")
 
-	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken"}
 
-	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	redactedSink, err := alogger.NewRedactingWriterWithURLCredSink(os.Stdout, logLevel, keyPatterns, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
 	}

--- a/src/autoscaler/metricscollector/cmd/metricscollector/main.go
+++ b/src/autoscaler/metricscollector/cmd/metricscollector/main.go
@@ -189,7 +189,14 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 		os.Exit(1)
 	}
 	logger := lager.NewLogger("metricscollector")
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, logLevel))
+
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+
+	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
+	}
+	logger.RegisterSink(redactedSink)
 
 	return logger
 }

--- a/src/autoscaler/pruner/cmd/pruner/main.go
+++ b/src/autoscaler/pruner/cmd/pruner/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"autoscaler/db/sqldb"
+	alogger "autoscaler/logger"
 	"autoscaler/pruner"
 	"autoscaler/pruner/config"
 
@@ -132,9 +133,9 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 	}
 	logger := lager.NewLogger("pruner")
 
-	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken"}
 
-	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	redactedSink, err := alogger.NewRedactingWriterWithURLCredSink(os.Stdout, logLevel, keyPatterns, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
 	}

--- a/src/autoscaler/pruner/cmd/pruner/main.go
+++ b/src/autoscaler/pruner/cmd/pruner/main.go
@@ -131,7 +131,14 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 		os.Exit(1)
 	}
 	logger := lager.NewLogger("pruner")
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, logLevel))
+
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+
+	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
+	}
+	logger.RegisterSink(redactedSink)
 
 	return logger
 }

--- a/src/autoscaler/scalingengine/cmd/scalingengine/main.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/main.go
@@ -9,6 +9,7 @@ import (
 	"autoscaler/cf"
 	"autoscaler/db"
 	"autoscaler/db/sqldb"
+	alogger "autoscaler/logger"
 	"autoscaler/scalingengine"
 	"autoscaler/scalingengine/config"
 	"autoscaler/scalingengine/schedule"
@@ -136,9 +137,9 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 	}
 	logger := lager.NewLogger("scalingengine")
 
-	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken"}
 
-	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	redactedSink, err := alogger.NewRedactingWriterWithURLCredSink(os.Stdout, logLevel, keyPatterns, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
 	}

--- a/src/autoscaler/scalingengine/cmd/scalingengine/main.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/main.go
@@ -135,7 +135,14 @@ func initLoggerFromConfig(conf *config.LoggingConfig) lager.Logger {
 		os.Exit(1)
 	}
 	logger := lager.NewLogger("scalingengine")
-	logger.RegisterSink(lager.NewWriterSink(os.Stdout, logLevel))
+
+	keyPatterns := []string{"[Pp]wd", "[Pp]ass", "[Ss]ecret", "[Tt]oken", "dbur[il]"}
+
+	redactedSink, err := lager.NewRedactingWriterSink(os.Stdout, logLevel, keyPatterns, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create redacted sink", err.Error())
+	}
+	logger.RegisterSink(redactedSink)
 
 	return logger
 }


### PR DESCRIPTION
example:
```
{"data":{"authUrl":"https://login.bosh-lite.com/oauth/token","form":{"client_id":["admin"],"client_secret":"*REDACTED*","grant_type":["client_credentials"]},"session":"1"},"log_level":1,"message":"metricscollector.cf.request-token-grant","source":"metricscollector","timestamp":"1510306805.491698027"}
```