### PR TITLE
add omitempty for optional parameters in ScalingPolicy Model and Schedules in ScalingPolicy Model

### DIFF
--- a/src/autoscaler/models/policy.go
+++ b/src/autoscaler/models/policy.go
@@ -39,18 +39,44 @@ func (p *PolicyJson) GetAppPolicy() *AppPolicy {
 type ScalingPolicy struct {
 	InstanceMin  int            `json:"instance_min_count"`
 	InstanceMax  int            `json:"instance_max_count"`
-	ScalingRules []*ScalingRule `json:"scaling_rules"`
+	ScalingRules []*ScalingRule `json:"scaling_rules,omitempty"`
+	Schedules    *ScalingSchedules `json:"schedules,omitempty"`
 }
 
 type ScalingRule struct {
 	MetricType            string `json:"metric_type"`
-	StatWindowSeconds     int    `json:"stat_window_secs"`
-	BreachDurationSeconds int    `json:"breach_duration_secs"`
+	StatWindowSeconds     int    `json:"stat_window_secs,omitempty"`
+	BreachDurationSeconds int    `json:"breach_duration_secs,omitempty"`
 	Threshold             int64  `json:"threshold"`
 	Operator              string `json:"operator"`
-	CoolDownSeconds       int    `json:"cool_down_secs"`
+	CoolDownSeconds       int    `json:"cool_down_secs,omitempty"`
 	Adjustment            string `json:"adjustment"`
 }
+
+type ScalingSchedules struct {
+	Timezone              string                  `json:"timezone"`
+	RecurringSchedules    []*RecurringSchedule    `json:"recurring_schedule,omitempty"`
+	SpecificDateSchedules []*SpecificDateSchedule `json:"specific_date,omitempty"`
+}
+
+type RecurringSchedule struct {
+	StartTime             string `json:"start_time"`
+	EndTime               string `json:"end_time"`
+	DaysOfWeek            []int  `json:"days_of_week,omitempty"`
+	DaysOfMonth           []int  `json:"days_of_month,omitempty"`
+	ScheduledInstanceMin  int    `json:"instance_min_count"`
+	ScheduledInstanceMax  int    `json:"instance_max_count"`
+	ScheduledInstanceInit int    `json:"initial_min_instance_count"`
+}
+
+type SpecificDateSchedule struct {
+	StartDateTime         string `json:"start_date_time"`
+	EndDateTime           string `json:"end_date_time"`
+	ScheduledInstanceMin  int    `json:"instance_min_count"`
+	ScheduledInstanceMax  int    `json:"instance_max_count"`
+	ScheduledInstanceInit int    `json:"initial_min_instance_count"`
+}
+
 
 func (r *ScalingRule) StatWindow(defaultStatWindowSecs int) time.Duration {
 	if r.StatWindowSeconds <= 0 {


### PR DESCRIPTION
[https://github.com/cloudfoundry-incubator/app-autoscaler-cli-plugin/pull/5#issuecomment-380366376](https://github.com/cloudfoundry-incubator/app-autoscaler-cli-plugin/pull/5#issuecomment-380366376)
This also fixes a bug which occurs when cli plugin is installed from this repo.
`cf autoscaling-policy` doesn't show schedules in policy.

@cdlliuy @boyang9527 
I think we should remove the cli plugin from this repo ? 