### PR TITLE
fix unexpected panic in loggin

### DIFF
--- a/src/autoscaler/eventgenerator/aggregator/metricPoller.go
+++ b/src/autoscaler/eventgenerator/aggregator/metricPoller.go
@@ -69,7 +69,7 @@ func (m *MetricPoller) retrieveMetric(app *models.AppMonitor) {
 	url = m.metricCollectorUrl + path.RequestURI() + "?" + parameters.Encode()
 	resp, err := m.httpClient.Get(url)
 	if err != nil {
-		m.logger.Error("Failed to retrieve metric from metrics collector. Request failed", err, lager.Data{"appId": appId, "metricType": metricType, "err": err})
+		m.logger.Error("Failed to retrieve metric from metrics collector. Request failed", err, lager.Data{"appId": appId, "metricType": metricType, "url": url})
 		return
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
We hit a panic in eventgen aggregator when its connection to metric collector failed due to tls certs issue.    When the connection fails with err,   we got unexpected panic when trying to marshal/unmarshal the logging data. 
A quick fix is delivered in this PR just to avoid the panic.   Given the "err" itself is included in logger.Error already, we skipped it in the lagger.data field. 

