### PR TITLE
bugfix: lose the cf erro response when it is not structured in json f…

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -16,11 +16,10 @@
 
 | Name                 | Type         | Required|Description                                                                      |
 |:---------------------|--------------|---------|---------------------------------------------------------------------------------|
-| metric_type          | String       | true    |one of the following metric types:memoryused,memoryutil,responsetime, throughput, cpu |      
-| breach_duration_secs | int, seconds | false   |time duration to fire scaling event if it keeps breaching                        |
-| threshold            | int          | true    |the boundary when metric value exceeds is considered as a breach                 |
+| metric_type          | String       | true    |one of the following metric types:memoryused,memoryutil,responsetime, throughput, cpu|| threshold            | int          | true    |the boundary when metric value exceeds is considered as a breach                 |
 | operator             | String       | true    |>, <, >=, <=                                                                     |
-| adjustment           | int          | true    |the adjustment for instance count with each scaling                              |
+| adjustment           | String       | true    |the adjustment approach for instance count with each scaling.  Support regex format `^[-+][1-9]+[0-9]*[%]?$`, i.e. +5 means adding 5 instances, -50% means shrinking to the half of current size.  |
+| breach_duration_secs | int, seconds | false   |time duration to fire scaling event if it keeps breaching                        |
 | cool_down_secs       | int,seconds  | false   |the time duration to wait before the next scaling kicks in                       |
 
 

--- a/src/autoscaler/cf/app.go
+++ b/src/autoscaler/cf/app.go
@@ -49,7 +49,7 @@ func (c *cfClient) GetApp(appId string) (*models.AppEntity, error) {
 			var bodydata map[string]interface{}
 			err = json.Unmarshal([]byte(respBody), &bodydata)
 			if err != nil {
-				c.logger.Error("failed-to-unmarshal-response-body-while-getting-app-summary", err, lager.Data{"appid": appId})
+				c.logger.Error("failed-to-unmarshal-response-body-while-getting-app-summary", err, lager.Data{"appid": appId, "error_response": string(respBody)})
 				return nil, err
 			}
 			errorDescription := bodydata["description"].(string)
@@ -119,7 +119,7 @@ func (c *cfClient) SetAppInstances(appID string, num int) error {
 		var bodydata map[string]interface{}
 		err = json.Unmarshal([]byte(respBody), &bodydata)
 		if err != nil {
-			c.logger.Error("failed-to-unmarshal-response-body-while-setting-app-instance", err, lager.Data{"appid": appID})
+			c.logger.Error("failed-to-unmarshal-response-body-while-setting-app-instance", err, lager.Data{"appid": appID, "error_response": string(respBody)})
 			return err
 		}
 		errorDescription := bodydata["description"].(string)

--- a/src/autoscaler/cf/app.go
+++ b/src/autoscaler/cf/app.go
@@ -19,8 +19,8 @@ const (
 	CFAppNotFound   = "CF-AppNotFound"
 )
 
-func (c *cfClient) GetApp(appId string) (*models.AppEntity, error) {
-	url := c.conf.API + path.Join(PathApp, appId, "summary")
+func (c *cfClient) GetApp(appID string) (*models.AppEntity, error) {
+	url := c.conf.API + path.Join(PathApp, appID, "summary")
 	c.logger.Debug("get-app-instances", lager.Data{"url": url})
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -43,13 +43,14 @@ func (c *cfClient) GetApp(appId string) (*models.AppEntity, error) {
 		if resp.StatusCode == 404 {
 			respBody, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				c.logger.Error("failed-to-read-response-body-while-getting-app-summary", err, lager.Data{"appid": appId})
+				c.logger.Error("failed-to-read-response-body-while-getting-app-summary", err, lager.Data{"appID": appID})
 				return nil, err
 			}
 			var bodydata map[string]interface{}
 			err = json.Unmarshal([]byte(respBody), &bodydata)
 			if err != nil {
-				c.logger.Error("failed-to-unmarshal-response-body-while-getting-app-summary", err, lager.Data{"appid": appId, "error_response": string(respBody)})
+				err = fmt.Errorf("%s", string(respBody))
+				c.logger.Error("failed-to-get-application-summary", err, lager.Data{"appID": appID})
 				return nil, err
 			}
 			errorDescription := bodydata["description"].(string)
@@ -62,7 +63,7 @@ func (c *cfClient) GetApp(appId string) (*models.AppEntity, error) {
 			} else {
 				err = fmt.Errorf("failed getting application summary: [%d] %s: %s", resp.StatusCode, errorCode, errorDescription)
 			}
-			c.logger.Error("get-app-summary-response", err, lager.Data{"appid": appId, "statusCode": resp.StatusCode, "description": errorDescription, "errorCode": errorCode})
+			c.logger.Error("get-app-summary-response", err, lager.Data{"appID": appID, "statusCode": resp.StatusCode, "description": errorDescription, "errorCode": errorCode})
 			return nil, err
 		}
 		// For Non 404 Error type
@@ -89,7 +90,7 @@ func (c *cfClient) SetAppInstances(appID string, num int) error {
 	}
 	body, err := json.Marshal(appEntity)
 	if err != nil {
-		c.logger.Error("set-app-instances-marshal", err, lager.Data{"appid": appID, "appEntity": appEntity})
+		c.logger.Error("set-app-instances-marshal", err, lager.Data{"appID": appID, "appEntity": appEntity})
 		return err
 	}
 
@@ -113,19 +114,20 @@ func (c *cfClient) SetAppInstances(appID string, num int) error {
 	if resp.StatusCode != http.StatusCreated {
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			c.logger.Error("failed-to-read-response-body-while-setting-app-instance", err, lager.Data{"appid": appID})
+			c.logger.Error("failed-to-read-response-body-while-setting-app-instance", err, lager.Data{"appID": appID})
 			return err
 		}
 		var bodydata map[string]interface{}
 		err = json.Unmarshal([]byte(respBody), &bodydata)
 		if err != nil {
-			c.logger.Error("failed-to-unmarshal-response-body-while-setting-app-instance", err, lager.Data{"appid": appID, "error_response": string(respBody)})
+			err = fmt.Errorf("%s", string(respBody))
+			c.logger.Error("faileded-to-set-application-instances", err, lager.Data{"appID": appID})
 			return err
 		}
 		errorDescription := bodydata["description"].(string)
 		errorCode := bodydata["error_code"].(string)
 		err = fmt.Errorf("failed setting application instances: [%d] %s: %s", resp.StatusCode, errorCode, errorDescription)
-		c.logger.Error("set-app-instances-response", err, lager.Data{"appid": appID, "statusCode": resp.StatusCode, "description": errorDescription, "errorCode": errorCode})
+		c.logger.Error("set-app-instances-response", err, lager.Data{"appID": appID, "statusCode": resp.StatusCode, "description": errorDescription, "errorCode": errorCode})
 		return err
 	}
 	return nil


### PR DESCRIPTION
In some cases, CC API didn't response a JSON format response .. i.e. when it has 500 internal error ..

So, this PR is used to display the original response when unmarshal fails.

also, adding a doc update to describe the definition of "adjustment" in policy