### PR TITLE
fix the intermittent failure in travis

### DIFF
--- a/src/autoscaler/operator/cmd/operator/operator_test.go
+++ b/src/autoscaler/operator/cmd/operator/operator_test.go
@@ -339,8 +339,12 @@ var _ = Describe("Operator", func() {
 		BeforeEach(func() {
 			runner.Start()
 			Eventually(runner.Session.Buffer, 2*time.Second).Should(gbytes.Say("operator.started"))
-
 		})
+
+		AfterEach(func() {
+			runner.ClearLockDatabase()
+		})
+
 		Context("when a request to query health comes", func() {
 			It("returns with a 200", func() {
 				rsp, err := healthHttpClient.Get(fmt.Sprintf("http://127.0.0.1:%d/health", healthport))

--- a/src/autoscaler/operator/config/config.go
+++ b/src/autoscaler/operator/config/config.go
@@ -20,7 +20,6 @@ const (
 	DefaultRefreshInterval     time.Duration = 24 * time.Hour
 	DefaultCutoffDuration      time.Duration = 30 * 24 * time.Hour
 	DefaultSyncInterval        time.Duration = 24 * time.Hour
-	DefaultLockTTL             time.Duration = locket.DefaultSessionTTL
 	DefaultRetryInterval       time.Duration = locket.RetryInterval
 	DefaultDBLockRetryInterval time.Duration = 5 * time.Second
 	DefaultDBLockTTL           time.Duration = 15 * time.Second


### PR DESCRIPTION
Travis build fails in operator due to unexpected "operator.lock-db.lock-still-valid".  Add  aftereach() section in the "health server" test section
